### PR TITLE
fix maxJobRunWaitTimeInSeconds from 10 min to 30 min

### DIFF
--- a/controllers/gatling_controller.go
+++ b/controllers/gatling_controller.go
@@ -37,9 +37,9 @@ import (
 )
 
 const (
-	requeueIntervalInSeconds           = 5    // 5 sec
-	maxJobCreationWaitTimeInSeconds    = 600  // 600 sec (10 min)
-	maxJobRunWaitTimeInSeconds         = 1800 // 1800 sec (30 min)
+	requeueIntervalInSeconds           = 5     // 5 sec
+	maxJobCreationWaitTimeInSeconds    = 600   // 600 sec (10 min)
+	maxJobRunWaitTimeInSeconds         = 10800 // 10800 sec (3 hours)
 	defaultGatlingImage                = "denvazh/gatling:latest"
 	defaultRcloneImage                 = "rclone/rclone:latest"
 	defaultSimulationsDirectoryPath    = "/opt/gatling/user-files/simulations"


### PR DESCRIPTION
Fix. https://github.com/st-tech/gatling-operator/issues/6

There is also a way to specify the maximum job execution time in Gatling Spec, but for now, 10 minutes is too short, so change it to 30 minutes.