### PR TITLE
add CleanupGatlingResourceAfterJobDone

### DIFF
--- a/api/v1alpha1/gatling_types.go
+++ b/api/v1alpha1/gatling_types.go
@@ -39,15 +39,10 @@ type GatlingSpec struct {
 	// +kubebuilder:validation:Optional
 	NotifyReport bool `json:"notifyReport,omitempty"`
 
-	// The flag of cleanup gatling jobs resources after the job done
+	// The flag of cleanup gatling resources after the job done
 	// +kubebuilder:default=false
 	// +kubebuilder:validation:Optional
 	CleanupAfterJobDone bool `json:"cleanupAfterJobDone,omitempty"`
-
-	// The flag of cleanup gatling jobs resources after the job done
-	// +kubebuilder:default=false
-	// +kubebuilder:validation:Optional
-	CleanupGatlingResourceAfterJobDone bool `json:"cleanupGatlingResourceAfterJobDone,omitempty"`
 
 	// Pod extra specification
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
+++ b/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
@@ -41,11 +41,6 @@ spec:
                 description: The flag of cleanup gatling jobs resources after the
                   job done
                 type: boolean
-              cleanupGatlingResourceAfterJobDone:
-                default: false
-                description: The flag of cleanup gatling jobs resources after the
-                  job done
-                type: boolean
               cloudStorageSpec:
                 description: Cloud Storage Provider
                 properties:

--- a/config/samples/gatling-operator_v1alpha1_gatling01.yaml
+++ b/config/samples/gatling-operator_v1alpha1_gatling01.yaml
@@ -6,7 +6,6 @@ spec:
   generateReport: false                                   # The flag of generating gatling report
   notifyReport: false                                     # The flag of notifying gatling report
   cleanupAfterJobDone: true                               #  The flag of cleaning up gatling jobs resources after the job done
-  cleanupGatlingResourceAfterJobDone: true                #  The flag of cleaning up gatling resources after the job done
   podSpec:
     gatlingImage: GATLING_IMAGE                           # Optional. Default: denvazh/gatling:latest. The image that will be used for Gatling container.
     rcloneImage: rclone/rclone                            # Optional. Default: rclone/rclone:latest. The image that will be used for rclone conatiner.

--- a/controllers/gatling_controller.go
+++ b/controllers/gatling_controller.go
@@ -78,14 +78,6 @@ func (r *GatlingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 		// Clean up Job resources if neccessary
 		if gatling.Spec.CleanupAfterJobDone {
-			log.Info(fmt.Sprintf("Cleaning up job %s for gatling %s", gatling.Status.RunnerJobName, gatling.Name))
-			r.cleanupJob(ctx, req, gatling.Status.RunnerJobName)
-			if gatling.Spec.GenerateReport {
-				log.Info(fmt.Sprintf("Cleaning up job %s for gatling %s", gatling.Status.ReporterJobName, gatling.Name))
-				r.cleanupJob(ctx, req, gatling.Status.ReporterJobName)
-			}
-		}
-		if gatling.Spec.CleanupGatlingResourceAfterJobDone {
 			log.Info(fmt.Sprintf("Cleaning up gatlig %s", gatling.Name))
 			r.cleanupGatling(ctx, req, gatling.Name)
 		}


### PR DESCRIPTION
# Description

fix for the https://github.com/st-tech/gatling-operator/issues/5

This change allows you to specify whether or not to delete the Gatling resource in `CleanupGatlingResourceAfterJobDone`.

This PR change is related to https://github.com/st-tech/gatling-operator/issues/14.
As isuue, in the current situation, if you delete the gatling resource, you will get an error.

# Test
Set `cleanupGatlingResourceAfterJobDone` to true, deployed the sample manifest, and confirmed that the Gatling resource will be removed after the job is completed.