### PR TITLE
fix #17

### DIFF
--- a/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
+++ b/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
@@ -38,8 +38,7 @@ spec:
             properties:
               cleanupAfterJobDone:
                 default: false
-                description: The flag of cleanup gatling jobs resources after the
-                  job done
+                description: The flag of cleanup gatling resources after the job done
                 type: boolean
               cloudStorageSpec:
                 description: Cloud Storage Provider

--- a/controllers/commands.go
+++ b/controllers/commands.go
@@ -13,7 +13,7 @@ SIMULATIONS_DIR_PATH=%s
 TEMP_SIMULATIONS_DIR_PATH=%s
 RESOURCES_DIR_PATH=%s
 RESULTS_DIR_PATH=%s
-START_TIME=%s
+START_TIME="%s"
 if [ -z "${START_TIME}" ]; then
   START_TIME=$(date +"%%Y-%%m-%%d %%H:%%M:%%S" --utc)
 fi

--- a/controllers/commands_test.go
+++ b/controllers/commands_test.go
@@ -28,7 +28,7 @@ SIMULATIONS_DIR_PATH=testSimulationDirectoryPath
 TEMP_SIMULATIONS_DIR_PATH=testTempSimulationsDirectoryPath
 RESOURCES_DIR_PATH=testResourcesDirectoryPath
 RESULTS_DIR_PATH=testResultsDirectoryPath
-START_TIME=2021-09-10 08:45:31
+START_TIME="2021-09-10 08:45:31"
 if [ -z "${START_TIME}" ]; then
   START_TIME=$(date +"%Y-%m-%d %H:%M:%S" --utc)
 fi


### PR DESCRIPTION
#17 bug fix

start_time was not a string, causing an error.

Error log ( runner job ):
```
│ /bin/sh: 01:24:31: not found
│ Wait until 2021-12-07 01:24:25
│ GATLING_HOME is set to /opt/gatling
```

After fix ( runner job ):
```
│ Wait until 2021-12-7 01:34:31
│ it's 1638840755 now and waiting until 1638840871 ...
│ it's 1638840756 now and waiting until 1638840871 ...
│ it's 1638840757 now and waiting until 1638840871 ...
```