### PR TITLE
Suppress delete events for Gatling operator reconciliation

### DIFF
--- a/controllers/gatling_controller.go
+++ b/controllers/gatling_controller.go
@@ -927,7 +927,7 @@ func (r *GatlingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&gatlingv1alpha1.Gatling{}).
 		WithEventFilter(predicate.Funcs{
 			DeleteFunc: func(e event.DeleteEvent) bool {
-				// Suppress Delete events as we don't take any action in the reconiliation loop
+				// Suppress Delete events as we don't take any action in the reconciliation loop
 				// when invoked after the gatlingv1alpha1.Gatling is actually deleted
 				return false
 			},


### PR DESCRIPTION
# Description 

Fix https://github.com/st-tech/gatling-operator/issues/14

Suppress Delete events as we don't take any action in the reconiliation loop when invoked after the gatlingv1alpha1.Gatling is actually deleted

# Test
In local depevelopment, I actually deploy gatling CR and deleted like this following

```
# deploy the operator to local KIND cluster
make kind-deploy
# deploy sample Gatling CR
make kind-sample-deploy

# delete Gatling CR
kubectl delete gatling gatling-sample01  
```
As a test result, I don't come up with any error even when gatlingv1alpha1.Gatling is actually deleted 🎉 🎉 🎉 

> Before this, I had an error like this when gatlingv1alpha1.Gatling is actually deleted.
```
2021-12-23T07:02:32.903Z        ERROR   controller-runtime.manager.controller.gatling.gatling.Reconcile Unable to fetch Gatling, thus no longer requeue     {"reconciler group": "gatling-operator.tech.zozo.com", "reconciler kind": "Gatling", "name": "gatling-sample01", "namespace": "default", "error": "Gatling.gatling-operator.tech.zozo.com \"gatling-sample01\" not found"}
github.com/go-logr/zapr.(*zapLogger).Error
        /go/pkg/mod/github.com/go-logr/zapr@v0.2.0/zapr.go:132
github.com/st-tech/gatling-operator/controllers.(*GatlingReconciler).Reconcile
        /workspace/controllers/gatling_controller.go:70
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:298
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:253
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:216
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1
        /go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:185
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
        /go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:155
k8s.io/apimachinery/pkg/util/wait.BackoffUntil
        /go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:156
k8s.io/apimachinery/pkg/util/wait.JitterUntil
        /go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:133
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext
        /go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:185
k8s.io/apimachinery/pkg/util/wait.UntilWithContext
        /go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:99
```

