### PR TITLE
Add release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     branches:
       - main
-      - add-release-ci
     paths-ignore:
       - '**.md'
       - '.gitignore'    
@@ -58,7 +57,7 @@ jobs:
 
   release:
     name: Build Push Release
-    #if: startsWith( github.ref, 'refs/tags/' )
+    if: startsWith( github.ref, 'refs/tags/' )
     runs-on: ubuntu-latest
     needs: test
     steps:
@@ -81,8 +80,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::0.0.1-alpha.2
-        #run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
# Description

Add release CI where the following steps are executed after test CI (merged in PR https://github.com/st-tech/gatling-operator/pull/19):

- CI trigger: tagging (semantic ver like v0.0.1)
- Create release YAML (all-in-one manifest for Gatling Operator)
- build and push the image to GHCR
- create release and upload the release YAML

the way we trigger the release CI is simply to tag the release like this:

```bash
git tag -a v0.1.0 -m "v0.1.0"
git push origin v0.1.0
```

Relevant issue #3

# Test 
CI has been run with [dummy trigger  and dummy tag](https://github.com/st-tech/gatling-operator/pull/23/commits/496153517925e79d47074cf75bc4c9d154f5f488) `v0.0.1-alpha.2` successfully. See this below

1. test GitHub Actions run: https://github.com/st-tech/gatling-operator/runs/4624459901?check_suite_focus=true
![スクリーンショット 2021-12-24 14 28 26](https://user-images.githubusercontent.com/82332/147320388-9ce3a2c5-ab80-48cb-a8cb-8d60e1efab31.png)


2. created release: https://github.com/st-tech/gatling-operator/releases/tag/refs%2Fpull%2F23%2Fmerge

![スクリーンショット 2021-12-24 14 31 20](https://user-images.githubusercontent.com/82332/147320467-1aa59c35-2c39-4281-88f9-ce4626b89750.png)

3. pushed images (ghcr.io): https://github.com/st-tech/fluent-pvc-operator/pkgs/container/gatling-operator

![スクリーンショット 2021-12-24 14 29 50](https://user-images.githubusercontent.com/82332/147320404-33876226-a8ba-4461-b665-39cfb735ecc5.png)

