### PR TITLE
Fix release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     branches:
       - main
-      - add-release-ci
     paths-ignore:
       - '**.md'
       - '.gitignore'    
@@ -58,7 +57,7 @@ jobs:
 
   release:
     name: Build Push Release
-    #if: startsWith( github.ref, 'refs/tags/' )
+    if: startsWith( github.ref, 'refs/tags/' )
     runs-on: ubuntu-latest
     needs: test
     steps:
@@ -79,8 +78,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::0.0.1-alpha.3
-        #run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
# Description 
Fix https://github.com/st-tech/gatling-operator/pull/23

Appropriate image path isn't set in the created release YAML in PR https://github.com/st-tech/gatling-operator/pull/23. 

# Test

CI has been run with dummy trigger and dummy tag v0.0.1-alpha.3 successfully, and image path was set in release YAML

- CI run successfully https://github.com/st-tech/gatling-operator/runs/4625400916?check_suite_focus=true
- Container image was pushed onto GitHub Container registry: https://github.com/st-tech/gatling-operator/pkgs/container/gatling-operator/12327010?tag=0.0.1-alpha.3
- A release for v0.0.1-alpha.3 ([link](https://github.com/st-tech/gatling-operator/releases/tag/refs%2Fpull%2F24%2Fmerge)) is created successfully and the YAML was uploaded onto it, and of source, an appropriate image path isn't set in the created release YAML like this:

> created release YAML - [gatling-operator-0.0.1-alpha.3.yaml](https://github.com/st-tech/gatling-operator/releases/download/refs%2Fpull%2F24%2Fmerge/gatling-operator-0.0.1-alpha.3.yaml)
```yaml
        - /manager
        image: ghcr.io/st-tech/gatling-operator:0.0.1-alpha.3
``` 
