### PR TITLE
fix gcs rclone create config command to assume uniform bucket-level access

### DIFF
--- a/controllers/commands.go
+++ b/controllers/commands.go
@@ -64,7 +64,8 @@ done
 	case "gcp":
 		template := `
 RESULTS_DIR_PATH=%s
-rclone config create gs "google cloud storage" --gcs-anonymous
+# assumes gcs bucket using uniform bucket-level access control
+rclone config create gs "google cloud storage" bucket_policy_only true --non-interactive
 # assumes each pod only contain single gatling log file but use for loop to use find command result
 for source in $(find ${RESULTS_DIR_PATH} -type f -name *.log)
 do
@@ -91,7 +92,8 @@ rclone copy --s3-no-check-bucket --s3-env-auth %s ${GATLING_AGGREGATE_DIR}
 	case "gcp":
 		template := `
 GATLING_AGGREGATE_DIR=%s
-rclone config create gs "google cloud storage" --gcs-anonymous
+# assumes gcs bucket using uniform bucket-level access control
+rclone config create gs "google cloud storage" bucket_policy_only true --non-interactive
 rclone copy %s ${GATLING_AGGREGATE_DIR}
 `
 		return fmt.Sprintf(template, resultsDirectoryPath, storagePath)
@@ -124,7 +126,8 @@ rclone copy ${GATLING_AGGREGATE_DIR} --exclude "*.log" --s3-no-check-bucket --s3
 	case "gcp":
 		template := `
 GATLING_AGGREGATE_DIR=%s
-rclone config create gs "google cloud storage" --gcs-anonymous
+# assumes gcs bucket using uniform bucket-level access control
+rclone config create gs "google cloud storage" bucket_policy_only true --non-interactive
 rclone copy ${GATLING_AGGREGATE_DIR} --exclude "*.log" %s
 `
 		return fmt.Sprintf(template, resultsDirectoryPath, storagePath)

--- a/controllers/commands_test.go
+++ b/controllers/commands_test.go
@@ -99,7 +99,8 @@ done
 			provider = "gcp"
 			expectedValue = `
 RESULTS_DIR_PATH=testResultsDirectoryPath
-rclone config create gs "google cloud storage" --gcs-anonymous
+# assumes gcs bucket using uniform bucket-level access control
+rclone config create gs "google cloud storage" bucket_policy_only true --non-interactive
 # assumes each pod only contain single gatling log file but use for loop to use find command result
 for source in $(find ${RESULTS_DIR_PATH} -type f -name *.log)
 do
@@ -167,7 +168,8 @@ rclone copy --s3-no-check-bucket --s3-env-auth testStoragePath ${GATLING_AGGREGA
 			provider = "gcp"
 			expectedValue = `
 GATLING_AGGREGATE_DIR=testResultsDirectoryPath
-rclone config create gs "google cloud storage" --gcs-anonymous
+# assumes gcs bucket using uniform bucket-level access control
+rclone config create gs "google cloud storage" bucket_policy_only true --non-interactive
 rclone copy testStoragePath ${GATLING_AGGREGATE_DIR}
 `
 		})
@@ -252,7 +254,8 @@ rclone copy ${GATLING_AGGREGATE_DIR} --exclude "*.log" --s3-no-check-bucket --s3
 			provider = "gcp"
 			expectedValue = `
 GATLING_AGGREGATE_DIR=testResultsDirectoryPath
-rclone config create gs "google cloud storage" --gcs-anonymous
+# assumes gcs bucket using uniform bucket-level access control
+rclone config create gs "google cloud storage" bucket_policy_only true --non-interactive
 rclone copy ${GATLING_AGGREGATE_DIR} --exclude "*.log" testStoragePath
 `
 		})


### PR DESCRIPTION
# Description
- Update rclone configuration for gcs case to assume that gcs bucket use uniform bucket-level access control
- This prevent gatling operator from creating no one accessible object in GCS and allows bucket owners to control access permission 

# Test

- built successfully and deployed controller manager

```
❯ make docker-build

❯ docker tag gatling-operator:20220117-151751 gcr.io/xxxx/gatling-operator:20220117-151751

❯ docker push gcr.io/xxxx/gatling-operator:20220117-151751
The push refers to repository [gcr.io/xxxx/gatling-operator]
ff99425d122b: Pushed
5b1fa8e3e100: Layer already exists
20220117-151751: digest: sha256:1eee753dfb69fc502342f2f112e2272e4f83cbc562e51522773954bfb919134e size: 739

❯ k edit deploy gatling-operator-controller-manager

❯ k get pod
NAME                                                   READY   STATUS      RESTARTS   AGE
gatling-operator-controller-manager-74597d47b9-mjcqj   2/2     Running     0          20m
```

- deployed gatling custom resource and confirm that they succeed and created reports in gcs bucket

```
❯ k get job
NAME                                        COMPLETIONS   DURATION   AGE
api-load-test-reporter   1/1           24s        14m
api-load-test-runner     1/1           5m20s      19m

❯ gsutil ls gs://gatling-operator-reports2/api-load-test/3393858636/
gs://gatling-operator-reports2/api-load-test/3393858636/index.html
gs://gatling-operator-reports2/api-load-test/3393858636/style/
```

- confirmed that files are able to be downloaded and reports can be seen properly in local environment

```
❯ gsutil -m cp -r \
  "gs://xxxx-gatling-operator-reports2/api-load-test/3393858636/" \
  .
If you experience problems with multiprocessing on MacOS, they might be related to https://bugs.python.org/issue33725. You can disable multiprocessing by editing your .boto config or by adding the following flag to your command: `-o "GSUtil:parallel_process_count=1"`. Note that multithreading is still available even if you disable multiprocessing.

Copying gs://gatling-operator-reports2/api-load-test/3393858636/index.html...
Copying gs://gatling-operator-reports2/api-load-test/3393858636/js/all_sessions.js...
Copying gs://gatling-operator-reports2/api-load-test/3393858636/js/assertions.xml...
```

![スクリーンショット 2022-01-17 15 45 14](https://user-images.githubusercontent.com/15966983/149733556-74286d1b-dfb7-49ad-8bfd-36d8d7109873.png)



- confirmed that index.html file viewed from authenticated url can not show its contents properly 
    - access to authenticated url is redirected to other domain and so relatively created url for other resources becomes  invalid
    - to make it viewable, we need to create Public URL which is not redirected to other domain


![スクリーンショット 2022-01-17 16 03 58](https://user-images.githubusercontent.com/15966983/149733388-15e5f088-9ae0-4ee6-bb50-292fb9a699de.png)


