### PR TITLE
add option to create reports in each pod

### DIFF
--- a/api/v1alpha1/gatling_types.go
+++ b/api/v1alpha1/gatling_types.go
@@ -34,6 +34,11 @@ type GatlingSpec struct {
 	// +kubebuilder:validation:Optional
 	GenerateReport bool `json:"generateReport,omitempty"`
 
+	// (Optional) The flag of generating gatling report at each pod
+	// +kubebuilder:default=false
+	// +kubebuilder:validation:Optional
+	GenerateLocalReport bool `json:"generateLocalReport,omitempty"`
+
 	// (Optional) The flag of notifying gatling report. Defaults to `false`
 	// +kubebuilder:default=false
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
+++ b/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
@@ -168,6 +168,11 @@ spec:
                 - bucket
                 - provider
                 type: object
+              generateLocalReport:
+                default: false
+                description: (Optional) The flag of generating gatling report at each
+                  pod
+                type: boolean
               generateReport:
                 default: false
                 description: (Optional) The flag of generating gatling report.  Defaults

--- a/controllers/commands.go
+++ b/controllers/commands.go
@@ -6,7 +6,7 @@ import (
 
 func getGatlingRunnerCommand(
 	simulationsDirectoryPath string, tempSimulationsDirectoryPath string, resourcesDirectoryPath string,
-	resultsDirectoryPath string, startTime string, simulationClass string) string {
+	resultsDirectoryPath string, startTime string, simulationClass string, generateLocalReport bool) string {
 
 	template := `
 SIMULATIONS_DIR_PATH=%s
@@ -38,15 +38,21 @@ fi
 if [ ! -d ${RESULTS_DIR_PATH} ]; then
   mkdir -p ${RESULTS_DIR_PATH}
 fi
-gatling.sh -sf ${SIMULATIONS_DIR_PATH} -s %s -rsf ${RESOURCES_DIR_PATH} -rf ${RESULTS_DIR_PATH} -nr
+gatling.sh -sf ${SIMULATIONS_DIR_PATH} -s %s -rsf ${RESOURCES_DIR_PATH} -rf ${RESULTS_DIR_PATH} %s
 `
+	generateLocalReportOption := "-nr"
+	if generateLocalReport {
+		generateLocalReportOption = ""
+	}
+
 	return fmt.Sprintf(template,
 		simulationsDirectoryPath,
 		tempSimulationsDirectoryPath,
 		resourcesDirectoryPath,
 		resultsDirectoryPath,
 		startTime,
-		simulationClass)
+		simulationClass,
+		generateLocalReportOption)
 }
 
 func getGatlingTransferResultCommand(resultsDirectoryPath string, provider string, region string, storagePath string) string {

--- a/controllers/gatling_controller.go
+++ b/controllers/gatling_controller.go
@@ -423,7 +423,8 @@ func (r *GatlingReconciler) newGatlingRunnerJobForCR(gatling *gatlingv1alpha1.Ga
 		r.getResourcesDirectoryPath(gatling),
 		r.getResultsDirectoryPath(gatling),
 		r.getGatlingRunnerJobStartTime(gatling),
-		gatling.Spec.TestScenarioSpec.SimulationClass)
+		gatling.Spec.TestScenarioSpec.SimulationClass,
+		r.getGenerateLocalReport(gatling))
 	log.Info("gatlingRunnerCommand:", "comand", gatlingRunnerCommand)
 
 	envVars := []corev1.EnvVar{}
@@ -941,6 +942,13 @@ func (r *GatlingReconciler) getResultsDirectoryPath(gatling *gatlingv1alpha1.Gat
 		path = gatling.Spec.TestScenarioSpec.ResultsDirectoryPath
 	}
 	return path
+}
+
+func (r *GatlingReconciler) getGenerateLocalReport(gatling *gatlingv1alpha1.Gatling) bool {
+	if &gatling.Spec.GenerateLocalReport == nil {
+		return false
+	}
+	return gatling.Spec.GenerateLocalReport
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/docs/api.md
+++ b/docs/api.md
@@ -58,6 +58,7 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `generateReport` _boolean_ | (Optional) The flag of generating gatling report.  Defaults to `false` |
+| `generateLocalReport` _boolean_ | (Optional) The flag of generating gatling report at each pod |
 | `notifyReport` _boolean_ | (Optional) The flag of notifying gatling report. Defaults to `false` |
 | `cleanupAfterJobDone` _boolean_ | (Optional) The flag of cleanup gatling resources after the job done. Defaults to `false` |
 | `podSpec` _[PodSpec](#podspec)_ | (Optional) Gatling Pod specification. |


### PR DESCRIPTION
# Description
- Added a `generateLocalReport` field to gatling manifest to control whether to create gatling simulation reports within each pod

# Use case
- Some operators just check one container std output instead of generated integrated report at cloud storage to see load test rough summary.


# Test


- gatling manifest with `generateLocalReport: true`
    - which run gatling with -nr option (create local report)

```
❯ k describe po zozo-feature-flags-api-load-test-runner-cq2pf | grep gatling.sh
      gatling.sh -sf ${SIMULATIONS_DIR_PATH} -s ZozoFeatureFlagsApi -rsf ${RESOURCES_DIR_PATH} -rf ${RESULTS_DIR_PATH}

❯ k logs -f api-load-test-runner-cq2pf -c gatling-runner

Wait until 2022-01-18 07:40:59
GATLING_HOME is set to /opt/gatling
Simulation Api started...

================================================================================
2022-01-18 07:41:15                                           0s elapsed
---- Requests ------------------------------------------------------------------
> Global                                                   (OK=1      KO=0     )

---- API (dev) ----------------------------------------------
[##########################################################################]100%
          waiting: 0      / active: 0      / done: 1
================================================================================

Simulation Api completed in 0 seconds
Parsing log file(s)...
Parsing log file(s) done
Generating reports...

================================================================================
---- Global Information --------------------------------------------------------
> request count                                          1 (OK=1      KO=0     )
> min response time                                    163 (OK=163    KO=-     )
> max response time                                    163 (OK=163    KO=-     )
> mean response time                                   163 (OK=163    KO=-     )
> std deviation                                          0 (OK=0      KO=-     )
> response time 50th percentile                        163 (OK=163    KO=-     )
> response time 75th percentile                        163 (OK=163    KO=-     )
> response time 95th percentile                        163 (OK=163    KO=-     )
> response time 99th percentile                        163 (OK=163    KO=-     )
> mean requests/sec                                      1 (OK=1      KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                             1 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================

Reports generated in 0s.
```

- gatling manifest with `generateLocalReport: false`
    - which run gatling without -nr option (not create local report)


```
❯ k describe po api-load-test-runner-hqzm5 | grep gatling.sh
      gatling.sh -sf ${SIMULATIONS_DIR_PATH} -s Api -rsf ${RESOURCES_DIR_PATH} -rf ${RESULTS_DIR_PATH} -nr

❯ k logs api-load-test-runner-hqzm5 -c gatling-runner
Wait until 2022-01-18 07:40:59
GATLING_HOME is set to /opt/gatling
Simulation Api started...

================================================================================
2022-01-18 07:41:15                                           0s elapsed
---- Requests ------------------------------------------------------------------
> Global                                                   (OK=1      KO=0     )

---- API (dev) ----------------------------------------------
[##########################################################################]100%
          waiting: 0      / active: 0      / done: 1
================================================================================

Simulation Api completed in 0 seconds
```