### PR TITLE
Changed default gatling image

### DIFF
--- a/api/v1alpha1/gatling_types.go
+++ b/api/v1alpha1/gatling_types.go
@@ -68,7 +68,7 @@ type GatlingSpec struct {
 
 // PodSpec defines type to configure Gatling Pod specification. For the idea of PodSpec, refer to [bitpoke/mysql-operator](https://github.com/bitpoke/mysql-operator/blob/master/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go)
 type PodSpec struct {
-	// (Optional) The image that will be used for Gatling container. Defaults to `denvazh/gatling:latest`
+	// (Optional) The image that will be used for Gatling container. Defaults to `ghcr.io/st-tech/gatling:latest`
 	// +kubebuilder:validation:Optional
 	GatlingImage string `json:"gatlingImage,omitempty"`
 

--- a/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
+++ b/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
@@ -820,7 +820,7 @@ spec:
                     type: object
                   gatlingImage:
                     description: (Optional) The image that will be used for Gatling
-                      container. Defaults to `denvazh/gatling:latest`
+                      container. Defaults to `ghcr.io/st-tech/gatling:latest`
                     type: string
                   rcloneImage:
                     description: (Optional) The image that will be used for rclone

--- a/config/samples/gatling-operator_v1alpha1_gatling01.yaml
+++ b/config/samples/gatling-operator_v1alpha1_gatling01.yaml
@@ -7,7 +7,7 @@ spec:
   notifyReport: false                                     # The flag of notifying gatling report
   cleanupAfterJobDone: true                               #  The flag of cleaning up gatling jobs resources after the job done
   podSpec:
-    gatlingImage: GATLING_IMAGE                           # Optional. Default: denvazh/gatling:latest. The image that will be used for Gatling container.
+    gatlingImage: GATLING_IMAGE                           # Optional. Default: ghcr.io/st-tech/gatling:latest. The image that will be used for Gatling container.
     rcloneImage: rclone/rclone                            # Optional. Default: rclone/rclone:latest. The image that will be used for rclone conatiner.
     resources:                                            # Optional. Resources specifies the resource limits of the container.
       limits:

--- a/config/samples/gatling-operator_v1alpha1_gatling02.yaml
+++ b/config/samples/gatling-operator_v1alpha1_gatling02.yaml
@@ -7,7 +7,7 @@ spec:
   notifyReport: false                                     # The flag of notifying gatling report
   cleanupAfterJobDone: true                               #  The flag of cleaning up gatling jobs resources after the job done
   podSpec:
-    gatlingImage: denvazh/gatling:latest                  # Optional. Default: denvazh/gatling:latest. The image that will be used for Gatling container.
+    gatlingImage: ghcr.io/st-tech/gatling:latest           # Optional. Default: ghcr.io/st-tech/gatling:latest. The image that will be used for Gatling container.
     rcloneImage: rclone/rclone                            # Optional. Default: rclone/rclone:latest. The image that will be used for rclone conatiner.
     resources:                                            # Optional. Resources specifies the resource limits of the container.
       limits:

--- a/controllers/gatling_controller.go
+++ b/controllers/gatling_controller.go
@@ -42,7 +42,7 @@ const (
 	requeueIntervalInSeconds           = 5     // 5 sec
 	maxJobCreationWaitTimeInSeconds    = 600   // 600 sec (10 min)
 	maxJobRunWaitTimeInSeconds         = 10800 // 10800 sec (3 hours)
-	defaultGatlingImage                = "denvazh/gatling:latest"
+	defaultGatlingImage                = "ghcr.io/st-tech/gatling:latest"
 	defaultRcloneImage                 = "rclone/rclone:latest"
 	defaultSimulationsDirectoryPath    = "/opt/gatling/user-files/simulations"
 	defaultResourcesDirectoryPath      = "/opt/gatling/user-files/resources"

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,7 +95,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `gatlingImage` _string_ | (Optional) The image that will be used for Gatling container. Defaults to `denvazh/gatling:latest` |
+| `gatlingImage` _string_ | (Optional) The image that will be used for Gatling container. Defaults to `ghcr.io/st-tech/gatling:latest` |
 | `rcloneImage` _string_ | (Optional) The image that will be used for rclone conatiner. Defaults to `rclone/rclone:latest` |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#resourcerequirements-v1-core)_ | (Optional) Resources specifies the resource limits of the container. |
 | `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#affinity-v1-core)_ | (Optional) Affinity specification. |


### PR DESCRIPTION
# Description

Changed default gatling image

Before: `denvazh/gatling:latest`
After:  `ghcr.io/st-tech/gatling:latest`

The new image is built with our managed files placed under [gatling-operator/gatling](https://github.com/st-tech/gatling-operator/tree/main/gatling), and it's Dockerfile is fully based upon [denvazh/gatling:3.2.1](https://github.com/denvazh/gatling/tree/master/3.2.1).  
In the future, we'll optimize gatling image and push it to our registry path

In addition, I've updated sample manifests, the CRD types comment, CRD, and relevant api docs as well

- config/samples/gatling-operator_v1alpha1_gatling01.yaml
- config/samples/gatling-operator_v1alpha1_gatling02.yaml
- docs/api.md
- api/v1alpha1/gatling_types.go
- config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml

# Test

I've deploy the new gatling operator and deploy Gatling CR whose gatling image is `ghcr.io/st-tech/gatling:latest`. I confirmed that the gatling scenario has run as expected.

```
make kind-deploy
make sample-deploy SAMPLE_IMG=ghcr.io/st-tech/gatling:latest
```