### PR TITLE
Fix manifests-release to exclude version from all-in-one manifest name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,4 +109,4 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
-          files: gatling-operator-${{ steps.get_version.outputs.VERSION }}.yaml
+          files: gatling-operator.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: CI
 on:
   push:
     branches:
-      - main
+      # - main
+      - fix_release_image_name
     tags:
       - "v*.*.*"
   pull_request:
@@ -11,7 +12,7 @@ on:
       - main
     paths-ignore:
       - '**.md'
-      - '.gitignore'    
+      - '.gitignore'
   workflow_dispatch:
 
 env:
@@ -87,14 +88,14 @@ jobs:
 
       - name: Create release YAML (gatling-operator.yaml)
         env:
-          VERSION: ${{ steps.get_version.outputs.VERSION }}      
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
           IMAGE_ID=$REGISTRY/$IMAGE_NAME
-          make manifests-release IMG=$IMAGE_ID:$VERSION VERSION=$VERSION
+          make manifests-release IMG=$IMAGE_ID:$VERSION
 
       - name: Publish images to the registry
         env:
-          VERSION: ${{ steps.get_version.outputs.VERSION }}      
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
           IMAGE_ID=$REGISTRY/$IMAGE_NAME
           echo IMAGE_ID=$IMAGE_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches:
-      # - main
-      - fix_release_image_name
+      - main
     tags:
       - "v*.*.*"
   pull_request:

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,9 @@ help: ## Display this help.
 
 kind-create: ## Create a kind cluster named ${KIND_CLUSTER_NAME} locally if necessary
 ifeq (1, $(shell kind get clusters | grep ${KIND_CLUSTER_NAME} | wc -l | tr -d ' '))
-	@echo "Cluster already exists" 
+	@echo "Cluster already exists"
 else
-	@echo "Creating Cluster"	
+	@echo "Creating Cluster"
 	kind create cluster --name ${KIND_CLUSTER_NAME} --image=kindest/node:${K8S_NODE_IMAGE} --config ${KIND_CONFIG_DIR}/cluster.yaml
 endif
 
@@ -64,11 +64,7 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 
 manifests-release: manifests kustomize ## Generate all-in-one manifest for release
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-ifeq ("latest","${VERSION}")
 	$(KUSTOMIZE) build config/default > gatling-operator.yaml
-else
-	$(KUSTOMIZE) build config/default > gatling-operator-${VERSION}.yaml
-endif
 
 docs: crd-ref-docs ## Generate API reference documentation from CRD types
 	cd config/crd-ref-docs
@@ -101,14 +97,14 @@ docker-push: docker-build ## Push docker image with the manager.
 
 kind-load-image: kind-create docker-build ## Load local docker image into the kind cluster
 	@echo "Loading image into kind"
-	kind load docker-image ${IMG} --name ${KIND_CLUSTER_NAME} -v 1 
+	kind load docker-image ${IMG} --name ${KIND_CLUSTER_NAME} -v 1
 
 kind-load-sample-image: kind-create sample-docker-build ## Load local docker image for sample Gatling into the kind cluster
 	@echo "Loading sample image into kind"
-	kind load docker-image ${SAMPLE_IMG} --name ${KIND_CLUSTER_NAME} -v 1 
+	kind load docker-image ${SAMPLE_IMG} --name ${KIND_CLUSTER_NAME} -v 1
 
 sample-docker-build: ## Build docker image for sample Gatling
-	cd gatling && docker build -t ${SAMPLE_IMG} .	
+	cd gatling && docker build -t ${SAMPLE_IMG} .
 
 sample-docker-push: sample-docker-build ## Push docker image for sample Gatling
 	docker push ${SAMPLE_IMG}


### PR DESCRIPTION
# Description
Remove the version information from the yaml generated by manifests-release.
The reason for removing it is that there is no need to put the version in the manifest since each version is uploaded separately.

before change: https://github.com/st-tech/gatling-operator/releases/download/v0.4.0/gatling-operator-0.4.0.yaml
after change: https://github.com/st-tech/gatling-operator/releases/download/v0.4.0/gatling-operator.yaml
# Test
I've setup dummy trigger in CI and I've tagged with dummy one v0.4.0-dummy and got an expected result like this:

release url: https://github.com/st-tech/gatling-operator/releases/tag/v0.4.0-dummy
action url: https://github.com/st-tech/gatling-operator/actions/runs/1750651152

<img width="1252" alt="スクリーンショット 2022-01-26 21 13 16" src="https://user-images.githubusercontent.com/33239455/151161133-d40fcc87-9e97-43a3-a655-7b5f84bafd19.png">

TODO: After the PR has been merged, remove both the dummy release and the tags