### PR TITLE
change gatling image for sample manifest

### DIFF
--- a/config/samples/gatling-basic-simulation-secrets.yaml
+++ b/config/samples/gatling-basic-simulation-secrets.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-data:
-  SECRET_KEY: bXlzZWNyZXRrZXl2YWx1ZQ==
-kind: Secret
-metadata:
-  name: gatling-basic-simulation-secrets
-type: Opaque

--- a/config/samples/gatling-notification-slack-secrets.yaml
+++ b/config/samples/gatling-notification-slack-secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   # dummy base64ed slack incoming webhook url
-  incoming-webhook-url: aHR0cHM6Ly9ob29rcy5zbGFjay5jb20vc2VydmljZXMvQUJDREVGR0hJL1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWA== 
+  incoming-webhook-url: aHR0cHM6Ly9ob29rcy5zbGFjay5jb20vc2VydmljZXMvQUJDREVGR0hJL1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWA==
 kind: Secret
 metadata:
   name: gatling-notification-slack-secrets

--- a/config/samples/gatling-operator_v1alpha1_gatling01.yaml
+++ b/config/samples/gatling-operator_v1alpha1_gatling01.yaml
@@ -8,7 +8,7 @@ spec:
   cleanupAfterJobDone: true                               #  The flag of cleaning up gatling jobs resources after the job done
   podSpec:
     serviceAccountName: "gatling-operator-worker"
-    gatlingImage: GATLING_IMAGE                           # Optional. Default: ghcr.io/st-tech/gatling:latest. The image that will be used for Gatling container.
+    gatlingImage: ghcr.io/st-tech/gatling:latest          # Optional. Default: ghcr.io/st-tech/gatling:latest. The image that will be used for Gatling container.
     rcloneImage: rclone/rclone                            # Optional. Default: rclone/rclone:latest. The image that will be used for rclone conatiner.
     resources:                                            # Optional. Resources specifies the resource limits of the container.
       limits:
@@ -58,8 +58,3 @@ spec:
         value: "1"
       - name: DURATION
         value: "1"
-      - name: SECRET_KEY
-        valueFrom:
-          secretKeyRef:
-            name: gatling-basic-simulation-secrets
-            key: SECRET_KEY

--- a/config/samples/gatling-operator_v1alpha1_gatling01.yaml
+++ b/config/samples/gatling-operator_v1alpha1_gatling01.yaml
@@ -4,6 +4,7 @@ metadata:
   name: gatling-sample01
 spec:
   generateReport: false                                   # The flag of generating gatling report
+  generateLocalReport: false                              # The flag of generating gatling report for each pod
   notifyReport: false                                     # The flag of notifying gatling report
   cleanupAfterJobDone: true                               #  The flag of cleaning up gatling jobs resources after the job done
   podSpec:

--- a/config/samples/gatling-operator_v1alpha1_gatling02.yaml
+++ b/config/samples/gatling-operator_v1alpha1_gatling02.yaml
@@ -3,7 +3,8 @@ kind: Gatling
 metadata:
   name: gatling-sample02
 spec:
-  generateReport: true                                   # The flag of generating gatling report
+  generateReport: true                                    # The flag of generating gatling report
+  generateLocalReport: false                              # The flag of generating gatling report for each pod
   notifyReport: false                                     # The flag of notifying gatling report
   cleanupAfterJobDone: true                               #  The flag of cleaning up gatling jobs resources after the job done
   podSpec:

--- a/config/samples/gatling-operator_v1alpha1_gatling02.yaml
+++ b/config/samples/gatling-operator_v1alpha1_gatling02.yaml
@@ -8,7 +8,7 @@ spec:
   cleanupAfterJobDone: true                               #  The flag of cleaning up gatling jobs resources after the job done
   podSpec:
     serviceAccountName: "gatling-operator-worker"
-    gatlingImage: ghcr.io/st-tech/gatling:latest           # Optional. Default: ghcr.io/st-tech/gatling:latest. The image that will be used for Gatling container.
+    gatlingImage: ghcr.io/st-tech/gatling:latest          # Optional. Default: ghcr.io/st-tech/gatling:latest. The image that will be used for Gatling container.
     rcloneImage: rclone/rclone                            # Optional. Default: rclone/rclone:latest. The image that will be used for rclone conatiner.
     resources:                                            # Optional. Resources specifies the resource limits of the container.
       limits:
@@ -34,7 +34,7 @@ spec:
     #  - name: AWS_SECRET_ACCESS_KEY
     #    value: xxxxxxxxxxxxxxx
   notificationServiceSpec:
-    provider: "slack"                                     # Notification provider name. Supported provider: "slack" 
+    provider: "slack"                                     # Notification provider name. Supported provider: "slack"
     secretName: "gatling-notification-slack-secrets"      # The name of secret in which all key/value sets needed for the notification are stored
   testScenarioSpec:
     # startTime: 2021-09-10 08:45:31                      # Optional. Start time of running test scenario in UTC. Format: %Y-%m-%d %H:%M:%S
@@ -50,11 +50,6 @@ spec:
         value: "2"
       - name: DURATION
         value: "10"
-      - name: SECRET_KEY
-        valueFrom:
-          secretKeyRef:
-            name: gatling-basic-simulation-secrets
-            key: SECRET_KEY
     simulationData:                                      # Optional. Default: empty string map. Simulation Scala data to be created as ConfigMap that is mounted on simulations dir
       MyBasicSimulation.scala: |
         // Sample originally from https://github.com/gatling/gatling/blob/400a125d7995d1b895c4cc4847ff15059d252948/gatling-bundle/src/main/scala/computerdatabase/BasicSimulation.scala

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,5 +1,4 @@
 resources:
-- gatling-worker-service-account.yaml
-- gatling-basic-simulation-secrets.yaml
 - gatling-notification-slack-secrets.yaml
 - gatling-operator_v1alpha1_gatling01.yaml
+- gatling-worker-service-account.yaml


### PR DESCRIPTION
# Description
Change the Gatling image in the sample manifest to `ghcr.io/st-tech/gatling:latest`
( The gatling image in gatling-operator_v1alpha1_gatling02.yaml has already been changed #35 )

In addition, I've removed extra Secret and env, as they are not used in the sample manifest

# TEST

Using the sample manifest, I confirmed that gatling works correctly.
```
kustomize build config/samples | kubectl apply -f -
```