### PR TITLE
Upgrade Golang version to 1.17 used in release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
+          go-version: '1.17'
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1


### PR DESCRIPTION
# Description

I upgraded go version used in build & test CI to 1.17 in PR https://github.com/st-tech/gatling-operator/pull/53, however the go version in release CI has NOT been upgrade, which was supposed to be upgraded.
So upgrade Golang version to 1.17 for release CI in this PR

# Test
It's already tested that the operator can be built and run with golang 1.17 as expected in the PR https://github.com/st-tech/gatling-operator/pull/53