### PR TITLE
Support Azure Blob Storage for Cloud Storage Provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY pkg/ pkg/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ The desired state of a distributed Gatling load testing is described through a K
   - `Affinity` (such as Node affinity) and `Tolerations` to be used by the scheduler to decide where a pod can be placed in the cluster
   - `Service accounts` for Pods
 - Reports
-  - Automated generating aggregated Gatling HTML reports and storing them to Cloud Storages such as AWS S3, Google Cloud Storage, etc. via [rclone](https://rclone.org/)
+  - Automated generating aggregated Gatling HTML reports and storing them to Cloud Storages such as `Amazon S3`, `Google Cloud Storage`, `Azure Blob Storage`. via [rclone](https://rclone.org/)
   - Allows credentials info for accessing the remote storage to be specified via Secret resource
 - Notification
-  - Automated posting webhook message and sending Gatling load testing result via notification providers such as Slack
+  - Automated posting webhook message and sending Gatling load testing result via notification providers such as `Slack`
   - Allows webhook URL info to be specified via Secret resource
 - Automated cleaning up Gatling resources
 

--- a/api/v1alpha1/gatling_types.go
+++ b/api/v1alpha1/gatling_types.go
@@ -99,7 +99,7 @@ type TestScenarioSpec struct {
 	// +kubebuilder:validation:Optional
 	StartTime string `json:"startTime,omitempty"`
 
-	// (Optional) Number of pods running at the same time. Defaults to `1` (Mininum `1`)
+	// (Optional) Number of pods running at the same time. Defaults to `1` (Minimum `1`)
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Optional

--- a/api/v1alpha1/gatling_types.go
+++ b/api/v1alpha1/gatling_types.go
@@ -141,7 +141,7 @@ type TestScenarioSpec struct {
 // CloudStorageSpec defines Cloud Storage Provider specification.
 type CloudStorageSpec struct {
 	// (Required) Provider specifies the cloud provider that will be used.
-	// Supported providers: `aws`, `gcp`
+	// Supported providers: `aws`, `gcp`, and `azure`
 	// +kubebuilder:validation:Required
 	Provider string `json:"provider"`
 

--- a/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
+++ b/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
@@ -160,7 +160,7 @@ spec:
                     type: array
                   provider:
                     description: '(Required) Provider specifies the cloud provider
-                      that will be used. Supported providers: `aws`, `gcp`'
+                      that will be used. Supported providers: `aws`, `gcp`, and `azure`'
                     type: string
                   region:
                     description: (Optional) Region Name.
@@ -1263,7 +1263,7 @@ spec:
                   parallelism:
                     default: 1
                     description: (Optional) Number of pods running at the same time.
-                      Defaults to `1` (Mininum `1`)
+                      Defaults to `1` (Minimum `1`)
                     format: int32
                     minimum: 1
                     type: integer

--- a/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
+++ b/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
@@ -60,13 +60,14 @@ spec:
                           type: string
                         value:
                           description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
                           type: string
                         valueFrom:
                           description: Source for the environment variable's value.
@@ -496,10 +497,71 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
                                     namespaces:
-                                      description: namespaces specifies which namespaces
-                                        the labelSelector applies to (matches against);
-                                        null or empty list means "this pod's namespace"
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -596,10 +658,69 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
                                 namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
@@ -696,10 +817,71 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
                                     namespaces:
-                                      description: namespaces specifies which namespaces
-                                        the labelSelector applies to (matches against);
-                                        null or empty list means "this pod's namespace"
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -796,10 +978,69 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
                                 namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
@@ -838,7 +1079,7 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                       requests:
                         additionalProperties:
@@ -850,7 +1091,7 @@ spec:
                         description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                   serviceAccountName:
@@ -916,13 +1157,14 @@ spec:
                           type: string
                         value:
                           description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
                           type: string
                         valueFrom:
                           description: Source for the environment variable's value.

--- a/config/samples/gatling-operator_v1alpha1_gatling01.yaml
+++ b/config/samples/gatling-operator_v1alpha1_gatling01.yaml
@@ -3,12 +3,10 @@ kind: Gatling
 metadata:
   name: gatling-sample01
 spec:
-  generateReport: true                                   # The flag of generating gatling report
-  #generateReport: false                                   # The flag of generating gatling report
+  generateReport: false                                   # The flag of generating gatling report
   generateLocalReport: false                              # The flag of generating gatling report for each pod
   notifyReport: false                                     # The flag of notifying gatling report
-  cleanupAfterJobDone: false                               #  The flag of cleaning up gatling jobs resources after the job done
-  #cleanupAfterJobDone: true                               #  The flag of cleaning up gatling jobs resources after the job done
+  cleanupAfterJobDone: true                               #  The flag of cleaning up gatling jobs resources after the job done
   podSpec:
     serviceAccountName: "gatling-operator-worker"
     gatlingImage: ghcr.io/st-tech/gatling:latest          # Optional. Default: ghcr.io/st-tech/gatling:latest. The image that will be used for Gatling container.
@@ -53,7 +51,6 @@ spec:
     #############################################################
     # provider: "gcp"
     # bucket: "gatling-operator-reports"                  # GCS bucket name on which Gatlilng report files are stored
-    # bucket: "zozo-mlops-dev-gatling-operator-reports"   # レポート用のGCSバケット zozo-mlops-dev(stg)-gatling-operator-reports を定義しているのでそちらを指定してください
     #
     #############################################################
     # .      Storage Provider - azure (Azure Blob Storage) ########
@@ -78,8 +75,7 @@ spec:
     secretName: "gatling-notification-slack-secrets"      # The name of secret in which all key/value sets needed for the notification are stored
   testScenarioSpec:
     # startTime: 2021-09-10 08:45:31                      # Optional. Start time of running test scenario in UTC. Format: %Y-%m-%d %H:%M:%S
-    parallelism: 1                                        # Optional. Default: 1. Number of pods running at any instant
-    #parallelism: 3                                        # Optional. Default: 1. Number of pods running at any instant
+    parallelism: 3                                        # Optional. Default: 1. Number of pods running at any instant
     # simulationsDirectoryPath: "/dir-path-to-simulation" # Optional. Default: /opt/gatling/user-files/simulations
     # resourcesDirectoryPath: "dir-path-to-resources"     # Optional. Default: /opt/gatling/user-files/resources
     # resultsDirectoryPath: "dir-path-to-results"         # Optional. Default: /opt/gatling/results.

--- a/config/samples/gatling-operator_v1alpha1_gatling01.yaml
+++ b/config/samples/gatling-operator_v1alpha1_gatling01.yaml
@@ -53,7 +53,7 @@ spec:
     # bucket: "gatling-operator-reports"                  # GCS bucket name on which Gatlilng report files are stored
     #
     #############################################################
-    # .      Storage Provider - azure (Azure Blob Storage) ########
+    #        Storage Provider - azure (Azure Blob Storage)
     #############################################################
     #provider: "azure"
     #bucket: "gatling-operator-reports"                   # Azure Blob Storage container name on which Gatlilng report files are stored

--- a/config/samples/gatling-operator_v1alpha1_gatling01.yaml
+++ b/config/samples/gatling-operator_v1alpha1_gatling01.yaml
@@ -3,10 +3,12 @@ kind: Gatling
 metadata:
   name: gatling-sample01
 spec:
-  generateReport: false                                   # The flag of generating gatling report
+  generateReport: true                                   # The flag of generating gatling report
+  #generateReport: false                                   # The flag of generating gatling report
   generateLocalReport: false                              # The flag of generating gatling report for each pod
   notifyReport: false                                     # The flag of notifying gatling report
-  cleanupAfterJobDone: true                               #  The flag of cleaning up gatling jobs resources after the job done
+  cleanupAfterJobDone: false                               #  The flag of cleaning up gatling jobs resources after the job done
+  #cleanupAfterJobDone: true                               #  The flag of cleaning up gatling jobs resources after the job done
   podSpec:
     serviceAccountName: "gatling-operator-worker"
     gatlingImage: ghcr.io/st-tech/gatling:latest          # Optional. Default: ghcr.io/st-tech/gatling:latest. The image that will be used for Gatling container.
@@ -30,10 +32,13 @@ spec:
         value: "non-kube-system"
         effect: "NoSchedule"
   cloudStorageSpec:
-    provider: "aws"                                       # Provider specifies the cloud provider that will be used. Supported providers: "aws", "gcp"
-    bucket: "gatling-operator-reports"                    # Bucket name in cloud storage service, on which Gatlilng report files are stored
+    #############################################################
+    #         Storage Provider - aws (AMAZON S3) 
+    #############################################################
+    provider: "aws"                                       # Provider specifies the cloud provider that will be used. Supported providers: "aws", "gcp", "azure"
+    bucket: "gatling-operator-reports"                    # S3 Bucket name on which Gatlilng report files are stored
     region: "ap-northeast-1"                              # Optional. Default: "ap-northeast-1" for aws provider. Region name
-    #env:                                                 # Optional. Environment variables to be used for connecting to the cloud providers
+    #env:                                                  # Optional. Environment variables to be used for connecting to the cloud providers
     #  # For S3 see also the env variables for auth: https://rclone.org/s3/#authentication
     #  - name: AWS_ACCESS_KEY_ID
     #    value: xxxxxxxxxxxxxxx
@@ -42,12 +47,39 @@ spec:
     #      secretKeyRef:
     #        name: aws-credentail-secrets
     #        key: AWS_SECRET_ACCESS_KEY
+    #
+    #############################################################
+    #        Storage Provider - gcp (Google Cloud Storage)
+    #############################################################
+    # provider: "gcp"
+    # bucket: "gatling-operator-reports"                  # GCS bucket name on which Gatlilng report files are stored
+    # bucket: "zozo-mlops-dev-gatling-operator-reports"   # レポート用のGCSバケット zozo-mlops-dev(stg)-gatling-operator-reports を定義しているのでそちらを指定してください
+    #
+    #############################################################
+    # .      Storage Provider - azure (Azure Blob Storage) ########
+    #############################################################
+    #provider: "azure"
+    #bucket: "gatling-operator-reports"                   # Azure Blob Storage container name on which Gatlilng report files are stored
+    #env:                                                 # Optional. Environment variables to be used for connecting to the cloud providers
+    #  - name: AZUREBLOB_ACCOUNT                          # Azure Blob Storage Account Name
+    #    value: xxxxxxxxxxxxxxx
+    #  - name: AZUREBLOB_KEY                              # Azure Blob Access Key. Leave blank to use SAS URL
+    #    valueFrom:
+    #      secretKeyRef:
+    #        name: azure-credentail-secrets
+    #        key: AZUREBLOBSS_KEY
+    #  - name: AZUREBLOB_SAS_URL                          # SAS URL. "Read, Write, List" permissions are required
+    #    valueFrom:
+    #      secretKeyRef:
+    #        name: azure-credentail-secrets
+    #        key: AZUREBLOB_SAS_URL
   notificationServiceSpec:
     provider: "slack"                                     # Notification provider name. Supported provider: "slack"
     secretName: "gatling-notification-slack-secrets"      # The name of secret in which all key/value sets needed for the notification are stored
   testScenarioSpec:
     # startTime: 2021-09-10 08:45:31                      # Optional. Start time of running test scenario in UTC. Format: %Y-%m-%d %H:%M:%S
-    parallelism: 3                                        # Optional. Default: 1. Number of pods running at any instant
+    parallelism: 1                                        # Optional. Default: 1. Number of pods running at any instant
+    #parallelism: 3                                        # Optional. Default: 1. Number of pods running at any instant
     # simulationsDirectoryPath: "/dir-path-to-simulation" # Optional. Default: /opt/gatling/user-files/simulations
     # resourcesDirectoryPath: "dir-path-to-resources"     # Optional. Default: /opt/gatling/user-files/resources
     # resultsDirectoryPath: "dir-path-to-results"         # Optional. Default: /opt/gatling/results.

--- a/config/samples/gatling-operator_v1alpha1_gatling02.yaml
+++ b/config/samples/gatling-operator_v1alpha1_gatling02.yaml
@@ -59,7 +59,7 @@ spec:
     #    valueFrom:
     #      secretKeyRef:
     #        name: azure-credentail-secrets
-    #        key: AZUREBLOBSS_KEY
+    #        key: AZUREBLOB_KEY
     #  - name: AZUREBLOB_SAS_URL                          # SAS URL. "Read, Write, List" permissions are required
     #    valueFrom:
     #      secretKeyRef:

--- a/config/samples/gatling-operator_v1alpha1_gatling02.yaml
+++ b/config/samples/gatling-operator_v1alpha1_gatling02.yaml
@@ -54,7 +54,7 @@ spec:
     #provider: "azure"
     #bucket: "gatling-operator-reports"                   # Azure Blob Storage container name on which Gatlilng report files are stored
     #env:                                                 # Optional. Environment variables to be used for connecting to the cloud providers
-    #  - name: AZUREBLOB_ACCOUNT                          # Azure Blob Storage Account Name. Leave blank to use SAS URL
+    #  - name: AZUREBLOB_ACCOUNT                          # Azure Blob Storage Account Name
     #    value: xxxxxxxxxxxxxxx
     #  - name: AZUREBLOB_KEY                              # Azure Blob Access Key. Leave blank to use SAS URL
     #    valueFrom:

--- a/config/samples/gatling-operator_v1alpha1_gatling02.yaml
+++ b/config/samples/gatling-operator_v1alpha1_gatling02.yaml
@@ -25,10 +25,13 @@ spec:
                   values:
                     - linux
   cloudStorageSpec:
-    provider: "aws"                                       # Provider specifies the cloud provider that will be used. Supported providers: "aws", "gcp"
-    bucket: "gatling-operator-reports"                    # Bucket name in cloud storage service, on which Gatlilng report files are stored
+    #############################################################
+    #         Storage Provider - aws (AMAZON S3) 
+    #############################################################
+    provider: "aws"                                       # Provider specifies the cloud provider that will be used. Supported providers: "aws", "gcp", "azure"
+    bucket: "gatling-operator-reports"                    # S3 Bucket name on which Gatlilng report files are stored
     region: "ap-northeast-1"                              # Optional. Default: "ap-northeast-1" for aws provider. Region name
-    #env:                                                 # Optional. Environment variables to be used for connecting to the cloud providers
+    #env:                                                  # Optional. Environment variables to be used for connecting to the cloud providers
     #  # For S3 see also the env variables for auth: https://rclone.org/s3/#authentication
     #  - name: AWS_ACCESS_KEY_ID
     #    value: xxxxxxxxxxxxxxx
@@ -37,6 +40,32 @@ spec:
     #      secretKeyRef:
     #        name: aws-credentail-secrets
     #        key: AWS_SECRET_ACCESS_KEY
+    #
+    #############################################################
+    #        Storage Provider - gcp (Google Cloud Storage)
+    #############################################################
+    # provider: "gcp"
+    # bucket: "gatling-operator-reports"                  # GCS bucket name on which Gatlilng report files are stored
+    # bucket: "zozo-mlops-dev-gatling-operator-reports"   # レポート用のGCSバケット zozo-mlops-dev(stg)-gatling-operator-reports を定義しているのでそちらを指定してください
+    #
+    #############################################################
+    # .      Storage Provider - azure (Azure Blob Storage) ########
+    #############################################################
+    #provider: "azure"
+    #bucket: "gatling-operator-reports"                   # Azure Blob Storage container name on which Gatlilng report files are stored
+    #env:                                                 # Optional. Environment variables to be used for connecting to the cloud providers
+    #  - name: AZUREBLOB_ACCOUNT                          # Azure Blob Storage Account Name. Leave blank to use SAS URL
+    #    value: xxxxxxxxxxxxxxx
+    #  - name: AZUREBLOB_KEY                              # Azure Blob Access Key. Leave blank to use SAS URL
+    #    valueFrom:
+    #      secretKeyRef:
+    #        name: azure-credentail-secrets
+    #        key: AZUREBLOBSS_KEY
+    #  - name: AZUREBLOB_SAS_URL                          # SAS URL. "Read, Write, List" permissions are required
+    #    valueFrom:
+    #      secretKeyRef:
+    #        name: azure-credentail-secrets
+    #        key: AZUREBLOB_SAS_URL
   notificationServiceSpec:
     provider: "slack"                                     # Notification provider name. Supported provider: "slack"
     secretName: "gatling-notification-slack-secrets"      # The name of secret in which all key/value sets needed for the notification are stored

--- a/config/samples/gatling-operator_v1alpha1_gatling02.yaml
+++ b/config/samples/gatling-operator_v1alpha1_gatling02.yaml
@@ -46,10 +46,9 @@ spec:
     #############################################################
     # provider: "gcp"
     # bucket: "gatling-operator-reports"                  # GCS bucket name on which Gatlilng report files are stored
-    # bucket: "zozo-mlops-dev-gatling-operator-reports"   # レポート用のGCSバケット zozo-mlops-dev(stg)-gatling-operator-reports を定義しているのでそちらを指定してください
     #
     #############################################################
-    # .      Storage Provider - azure (Azure Blob Storage) ########
+    #        Storage Provider - azure (Azure Blob Storage)
     #############################################################
     #provider: "azure"
     #bucket: "gatling-operator-reports"                   # Azure Blob Storage container name on which Gatlilng report files are stored

--- a/controllers/gatling_controller.go
+++ b/controllers/gatling_controller.go
@@ -439,10 +439,7 @@ func (r *GatlingReconciler) newGatlingRunnerJobForCR(gatling *gatlingv1alpha1.Ga
 		r.getGenerateLocalReport(gatling))
 	log.Info("gatlingRunnerCommand:", "comand", gatlingRunnerCommand)
 
-	envVars := []corev1.EnvVar{}
-	if &gatling.Spec.TestScenarioSpec != nil && &gatling.Spec.TestScenarioSpec.Env != nil {
-		envVars = gatling.Spec.TestScenarioSpec.Env
-	}
+	envVars := gatling.Spec.TestScenarioSpec.Env
 	if gatling.Spec.GenerateReport {
 		gatlingTransferResultCommand := commands.GetGatlingTransferResultCommand(
 			r.getResultsDirectoryPath(gatling),
@@ -450,10 +447,7 @@ func (r *GatlingReconciler) newGatlingRunnerJobForCR(gatling *gatlingv1alpha1.Ga
 			r.getCloudStorageRegion(gatling),
 			storagePath)
 		log.Info("gatlingTransferResultCommand:", "command", gatlingTransferResultCommand)
-		cloudStorageEnvVars := []corev1.EnvVar{}
-		if &gatling.Spec.CloudStorageSpec != nil && &gatling.Spec.CloudStorageSpec.Env != nil {
-			cloudStorageEnvVars = gatling.Spec.CloudStorageSpec.Env
-		}
+		cloudStorageEnvVars := gatling.Spec.CloudStorageSpec.Env
 		return &batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      gatling.Name + "-runner",
@@ -584,10 +578,7 @@ func (r *GatlingReconciler) newGatlingReporterJobForCR(gatling *gatlingv1alpha1.
 		storagePath)
 	log.Info("gatlingTransferReportCommand", "command", gatlingTransferReportCommand)
 
-	cloudStorageEnvVars := []corev1.EnvVar{}
-	if &gatling.Spec.CloudStorageSpec != nil && &gatling.Spec.CloudStorageSpec.Env != nil {
-		cloudStorageEnvVars = gatling.Spec.CloudStorageSpec.Env
-	}
+	cloudStorageEnvVars := gatling.Spec.CloudStorageSpec.Env
 	//Non parallel job
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -746,7 +737,7 @@ func (r *GatlingReconciler) getCloudStorageInfo(ctx context.Context, gatling *ga
 		// Assign new Gatling Cloud Storage Path and report URL,
 		// and save them on Gatling Status fields
 		subDir := fmt.Sprint(utils.Hash(fmt.Sprintf("%s%d", gatling.Name, rand.Intn(math.MaxInt32))))
-		cspp := cloudstorages.GetProvider(r.getCloudStorageProvider(gatling))
+		cspp := cloudstorages.GetProvider(r.getCloudStorageProvider(gatling), gatling.Spec.CloudStorageSpec.Env)
 		if cspp != nil {
 			storagePath = (*cspp).GetCloudStoragePath(r.getCloudStorageBucket(gatling), gatling.Name, subDir)
 			reportURL = (*cspp).GetCloudStorageReportURL(r.getCloudStorageBucket(gatling), gatling.Name, subDir)

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,7 +24,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `provider` _string_ | (Required) Provider specifies the cloud provider that will be used. Supported providers: `aws`, `gcp` |
+| `provider` _string_ | (Required) Provider specifies the cloud provider that will be used. Supported providers: `aws`, `gcp`, and `azure` |
 | `bucket` _string_ | (Required) Storage Bucket Name. |
 | `region` _string_ | (Optional) Region Name. |
 | `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#envvar-v1-core) array_ | (Optional) Environment variables used for connecting to the cloud providers. |
@@ -115,7 +115,7 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `startTime` _string_ | (Optional) Test Start time. |
-| `parallelism` _integer_ | (Optional) Number of pods running at the same time. Defaults to `1` (Minimum `1`) |
+| `parallelism` _integer_ | (Optional) Number of pods running at the same time. Defaults to `1` (Mininum `1`) |
 | `simulationsDirectoryPath` _string_ | (Optional) Gatling Resources directory path where simulation files are stored. Defaults to `/opt/gatling/user-files/simulations` |
 | `resourcesDirectoryPath` _string_ | (Optional) Gatling Simulation directory path where resources are stored. Defaults to `/opt/gatling/user-files/resources` |
 | `resultsDirectoryPath` _string_ | (Optional) Gatling Results directory path where results are stored. Defaults to `/opt/gatling/results` |
@@ -123,6 +123,6 @@ _Appears in:_
 | `simulationData` _object (keys:string, values:string)_ | (Optional) Simulation Data. |
 | `resourceData` _object (keys:string, values:string)_ | (Optional) Resource Data. |
 | `gatlingConf` _object (keys:string, values:string)_ | (Optional) Gatling Configurations. |
-| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#envvar-v1-core)_ | (Optional) Environment variables used for running load testing scenario. |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#envvar-v1-core) array_ | (Optional) Environment variables used for running load testing scenario. |
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -115,7 +115,7 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `startTime` _string_ | (Optional) Test Start time. |
-| `parallelism` _integer_ | (Optional) Number of pods running at the same time. Defaults to `1` (Mininum `1`) |
+| `parallelism` _integer_ | (Optional) Number of pods running at the same time. Defaults to `1` (Minimum `1`) |
 | `simulationsDirectoryPath` _string_ | (Optional) Gatling Resources directory path where simulation files are stored. Defaults to `/opt/gatling/user-files/simulations` |
 | `resourcesDirectoryPath` _string_ | (Optional) Gatling Simulation directory path where resources are stored. Defaults to `/opt/gatling/user-files/resources` |
 | `resultsDirectoryPath` _string_ | (Optional) Gatling Results directory path where results are stored. Defaults to `/opt/gatling/results` |

--- a/pkg/cloudstorages/aws.go
+++ b/pkg/cloudstorages/aws.go
@@ -8,6 +8,8 @@ type AWSCloudStorageProvider struct {
 	providerName string
 }
 
+func (p *AWSCloudStorageProvider) init(args []EnvVars) { /* do nothinig */ }
+
 func (p *AWSCloudStorageProvider) GetName() string {
 	return p.providerName
 }

--- a/pkg/cloudstorages/aws.go
+++ b/pkg/cloudstorages/aws.go
@@ -8,7 +8,7 @@ type AWSCloudStorageProvider struct {
 	providerName string
 }
 
-func (p *AWSCloudStorageProvider) init(args []EnvVars) { /* do nothinig */ }
+func (p *AWSCloudStorageProvider) init(args []EnvVars) { /* do nothing */ }
 
 func (p *AWSCloudStorageProvider) GetName() string {
 	return p.providerName

--- a/pkg/cloudstorages/azure.go
+++ b/pkg/cloudstorages/azure.go
@@ -1,0 +1,78 @@
+package cloudstorages
+
+import (
+	"fmt"
+)
+
+type AzureCloudStorageProvider struct {
+	providerName   string
+	storageAccount string
+}
+
+func (p *AzureCloudStorageProvider) init(args []EnvVars) {
+	if len(args) > 0 {
+		var envs EnvVars = args[0]
+		for _, env := range envs {
+			if env.Name == "AZUREBLOB_ACCOUNT" {
+				p.storageAccount = env.Value
+				break
+			}
+		}
+	}
+}
+
+func (p *AzureCloudStorageProvider) GetName() string {
+	return p.providerName
+}
+
+func (p *AzureCloudStorageProvider) GetCloudStoragePath(bucket string, gatlingName string, subDir string) string {
+	// Format azureblob:<bucket>/<gatling-name>/<sub-dir>
+	return fmt.Sprintf("az:%s/%s/%s", bucket, gatlingName, subDir)
+}
+
+func (p *AzureCloudStorageProvider) GetCloudStorageReportURL(bucket string, gatlingName string, subDir string) string {
+	// Format https://<storage-account>.blob.core.windows.net/bucket/<gatling-name>/subdir/hoge.log
+	return fmt.Sprintf("https://%s.blob.core.windows.net/%s/%s/%s/index.html", p.storageAccount, bucket, gatlingName, subDir)
+}
+
+func (p *AzureCloudStorageProvider) GetGatlingTransferResultCommand(resultsDirectoryPath string, region string, storagePath string) string {
+	// region param isn't used
+	template := `
+export RCLONE_AZUREBLOB_ACCOUNT=${AZUREBLOB_ACCOUNT}
+export RCLONE_AZUREBLOB_KEY=${AZUREBLOB_KEY}
+export RCLONE_AZUREBLOB_SAS_URL=${AZUREBLOB_SAS_URL}
+RESULTS_DIR_PATH=%s
+rclone config create az azureblob env_auth=true
+for source in $(find ${RESULTS_DIR_PATH} -type f -name *.log)
+do
+	rclone copyto ${source} %s/${HOSTNAME}.log
+done
+`
+	return fmt.Sprintf(template, resultsDirectoryPath, storagePath)
+}
+
+func (p *AzureCloudStorageProvider) GetGatlingAggregateResultCommand(resultsDirectoryPath string, region string, storagePath string) string {
+	// region param isn't used
+	template := `
+export RCLONE_AZUREBLOB_ACCOUNT=${AZUREBLOB_ACCOUNT}
+export RCLONE_AZUREBLOB_KEY=${AZUREBLOB_KEY}
+export RCLONE_AZUREBLOB_SAS_URL=${AZUREBLOB_SAS_URL}
+GATLING_AGGREGATE_DIR=%s
+rclone config create az azureblob env_auth=true
+rclone copy %s ${GATLING_AGGREGATE_DIR}
+`
+	return fmt.Sprintf(template, resultsDirectoryPath, storagePath)
+}
+
+func (p *AzureCloudStorageProvider) GetGatlingTransferReportCommand(resultsDirectoryPath string, region string, storagePath string) string {
+	// region param isn't used
+	template := `
+export RCLONE_AZUREBLOB_ACCOUNT=${AZUREBLOB_ACCOUNT}
+export RCLONE_AZUREBLOB_KEY=${AZUREBLOB_KEY}
+export RCLONE_AZUREBLOB_SAS_URL=${AZUREBLOB_SAS_URL}
+GATLING_AGGREGATE_DIR=%s
+rclone config create az azureblob env_auth=true
+rclone copy ${GATLING_AGGREGATE_DIR} --exclude "*.log" %s
+`
+	return fmt.Sprintf(template, resultsDirectoryPath, storagePath)
+}

--- a/pkg/cloudstorages/azure_test.go
+++ b/pkg/cloudstorages/azure_test.go
@@ -1,0 +1,182 @@
+package cloudstorages
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var storageAccount string = "testaccount"
+
+var cspArgs []EnvVars = []EnvVars{
+	{
+		{
+			Name:  "AZUREBLOB_ACCOUNT",
+			Value: storageAccount,
+		},
+	},
+}
+
+var _ = Describe("GetName", func() {
+	var (
+		provider      string
+		expectedValue string
+	)
+	BeforeEach(func() {
+		provider = "azure"
+		expectedValue = "azure"
+	})
+	Context("Provider is azure", func() {
+		It("should get provider name = azure", func() {
+			csp := &AzureCloudStorageProvider{providerName: provider}
+			csp.init(cspArgs)
+			Expect(csp.GetName()).To(Equal(expectedValue))
+		})
+	})
+})
+
+var _ = Describe("GetCloudStoragePath", func() {
+	var (
+		provider      string
+		bucket        string
+		gatlingName   string
+		subDir        string
+		expectedValue string
+	)
+	BeforeEach(func() {
+		provider = "azure"
+		bucket = "testBucket"
+		gatlingName = "testGatling"
+		subDir = "subDir"
+		expectedValue = fmt.Sprintf("az:%s/%s/%s", bucket, gatlingName, subDir)
+	})
+	Context("Provider is azure", func() {
+		It("path is azure blob storage container", func() {
+			csp := &AzureCloudStorageProvider{providerName: provider}
+			csp.init(cspArgs)
+			Expect(csp.GetCloudStoragePath(bucket, gatlingName, subDir)).To(Equal(expectedValue))
+		})
+	})
+})
+
+var _ = Describe("GetCloudStorageReportURL", func() {
+	var (
+		provider      string
+		bucket        string
+		gatlingName   string
+		subDir        string
+		expectedValue string
+	)
+	BeforeEach(func() {
+		provider = "azure"
+		bucket = "testBucket"
+		gatlingName = "testGatling"
+		subDir = "subDir"
+		expectedValue = fmt.Sprintf("https://%s.blob.core.windows.net/%s/%s/%s/index.html",
+			storageAccount, bucket, gatlingName, subDir)
+	})
+	Context("Provider is azure", func() {
+		It("path is azure s3 bucket", func() {
+			csp := &AzureCloudStorageProvider{providerName: provider}
+			csp.init(cspArgs)
+			Expect(csp.GetCloudStorageReportURL(bucket, gatlingName, subDir)).To(Equal(expectedValue))
+		})
+	})
+})
+
+var _ = Describe("GetGatlingTransferResultCommand", func() {
+	var (
+		provider             string
+		resultsDirectoryPath string
+		region               string
+		storagePath          string
+		expectedValue        string
+	)
+	BeforeEach(func() {
+		provider = "azure"
+		resultsDirectoryPath = "testResultsDirectoryPath"
+		region = ""
+		storagePath = "testStoragePath"
+		expectedValue = fmt.Sprintf(`
+export RCLONE_AZUREBLOB_ACCOUNT=${AZUREBLOB_ACCOUNT}
+export RCLONE_AZUREBLOB_KEY=${AZUREBLOB_KEY}
+export RCLONE_AZUREBLOB_SAS_URL=${AZUREBLOB_SAS_URL}
+RESULTS_DIR_PATH=%s
+rclone config create az azureblob env_auth=true
+for source in $(find ${RESULTS_DIR_PATH} -type f -name *.log)
+do
+	rclone copyto ${source} %s/${HOSTNAME}.log
+done
+`, resultsDirectoryPath, storagePath)
+	})
+	Context("Provider is azure", func() {
+		It("returns commands with azure blob storage rclone config", func() {
+			csp := &AzureCloudStorageProvider{providerName: provider}
+			csp.init(cspArgs)
+			fmt.Println(csp.GetGatlingTransferResultCommand(resultsDirectoryPath, region, storagePath))
+			Expect(csp.GetGatlingTransferResultCommand(resultsDirectoryPath, region, storagePath)).To(Equal(expectedValue))
+		})
+	})
+})
+
+var _ = Describe("GetGatlingAggregateResultCommand", func() {
+	var (
+		provider             string
+		resultsDirectoryPath string
+		region               string
+		storagePath          string
+		expectedValue        string
+	)
+	BeforeEach(func() {
+		provider = "azure"
+		resultsDirectoryPath = "testResultsDirectoryPath"
+		region = ""
+		storagePath = "testStoragePath"
+		expectedValue = fmt.Sprintf(`
+export RCLONE_AZUREBLOB_ACCOUNT=${AZUREBLOB_ACCOUNT}
+export RCLONE_AZUREBLOB_KEY=${AZUREBLOB_KEY}
+export RCLONE_AZUREBLOB_SAS_URL=${AZUREBLOB_SAS_URL}
+GATLING_AGGREGATE_DIR=%s
+rclone config create az azureblob env_auth=true
+rclone copy %s ${GATLING_AGGREGATE_DIR}
+`, resultsDirectoryPath, storagePath)
+	})
+	Context("Provider is azure", func() {
+		It("returns commands with azure blob storage rclone config", func() {
+			csp := &AzureCloudStorageProvider{providerName: provider}
+			csp.init(cspArgs)
+			Expect(csp.GetGatlingAggregateResultCommand(resultsDirectoryPath, region, storagePath)).To(Equal(expectedValue))
+		})
+	})
+})
+
+var _ = Describe("GetGatlingTransferReportCommand", func() {
+	var (
+		provider             string
+		resultsDirectoryPath string
+		region               string
+		storagePath          string
+		expectedValue        string
+	)
+	BeforeEach(func() {
+		provider = "azure"
+		resultsDirectoryPath = "testResultsDirectoryPath"
+		region = ""
+		storagePath = "testStoragePath"
+		expectedValue = fmt.Sprintf(`
+export RCLONE_AZUREBLOB_ACCOUNT=${AZUREBLOB_ACCOUNT}
+export RCLONE_AZUREBLOB_KEY=${AZUREBLOB_KEY}
+export RCLONE_AZUREBLOB_SAS_URL=${AZUREBLOB_SAS_URL}
+GATLING_AGGREGATE_DIR=%s
+rclone config create az azureblob env_auth=true
+rclone copy ${GATLING_AGGREGATE_DIR} --exclude "*.log" %s
+`, resultsDirectoryPath, storagePath)
+	})
+	Context("Provider is azure", func() {
+		It("returns commands with azure blob storage rclone config", func() {
+			csp := &AzureCloudStorageProvider{providerName: provider}
+			Expect(csp.GetGatlingTransferReportCommand(resultsDirectoryPath, region, storagePath)).To(Equal(expectedValue))
+		})
+	})
+})

--- a/pkg/cloudstorages/gcp.go
+++ b/pkg/cloudstorages/gcp.go
@@ -8,7 +8,7 @@ type GCPCloudStorageProvider struct {
 	providerName string
 }
 
-func (p *GCPCloudStorageProvider) init(args []EnvVars) { /* do nothinig */ }
+func (p *GCPCloudStorageProvider) init(args []EnvVars) { /* do nothing */ }
 
 func (p *GCPCloudStorageProvider) GetName() string {
 	return p.providerName

--- a/pkg/cloudstorages/gcp.go
+++ b/pkg/cloudstorages/gcp.go
@@ -1,10 +1,14 @@
 package cloudstorages
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type GCPCloudStorageProvider struct {
 	providerName string
 }
+
+func (p *GCPCloudStorageProvider) init(args []EnvVars) { /* do nothinig */ }
 
 func (p *GCPCloudStorageProvider) GetName() string {
 	return p.providerName


### PR DESCRIPTION
### Description

Support Azure Blob Storage as Cloud Storage Provider 
Relevant Issue: https://github.com/st-tech/gatling-operator/issues/38

## What's been changed / added?
- [Add Azure Blob Storage for Cloud Storage Provider and its test](https://github.com/st-tech/gatling-operator/pull/59/commits/c7146abd2a561a2d12898f4a069a5750c537ae68)
- [refactored csp so that init func is called in initialization](https://github.com/st-tech/gatling-operator/commit/da251eb545e9ae24f082ef41c38ba8c591a70779)
- [update CRD to support Azure CSP](https://github.com/st-tech/gatling-operator/commit/f65273ae1a80e2056d8aa546b22892eb0e06a868)
- [Update API Docs](https://github.com/st-tech/gatling-operator/commit/fa8449f45e9679aae07d9c178ff831ce1e3c73ef)
- [Add Azure configuration to sample gatling manifests](https://github.com/st-tech/gatling-operator/commit/92da305e13a67dd04404652370cef2c6799a614c)
- [Add Azure Blob Storage to README description](https://github.com/st-tech/gatling-operator/commit/576645be674793889f311482e1109a0925d7f3ae)

## How to configure Gatling CR to use Azure Blob Storage?

There are 2 ways to configure  Azure Blob Storage access authentication

### (1). Authenticating with Azure Blob Storage using AZUREBLOB_ACCOUNT and AZUREBLOB_KEY 

```yaml
provider: "azure"
bucket: "gatling-operator-reports"                   # Azure Blob Storage container name on which Gatlilng report files are stored
env:                                                 # Optional. Environment variables to be used for connecting to the cloud providers
      - name: AZUREBLOB_ACCOUNT                          # Azure Blob Storage Account Name
        value: xxxxxxxxxxxxxxx
      - name: AZUREBLOB_KEY                              # Azure Blob Access Key. Leave blank to use SAS URL
        valueFrom:
          secretKeyRef:
            name: azure-credentail-secrets
            key: AZUREBLOBSS_KEY
```

### (2).Authenticating with Azure Blob Storage using AZUREBLOB_ACCOUNT and AZUREBLOB_SAS_URL

```yaml
provider: "azure"
bucket: "gatling-operator-reports"                   # Azure Blob Storage container name on which Gatlilng report files are stored
env:                                                 # Optional. Environment variables to be used for connecting to the cloud providers
      - name: AZUREBLOB_ACCOUNT                          # Azure Blob Storage Account Name
        value: xxxxxxxxxxxxxxx
      - name: AZUREBLOB_KEY                              # Azure Blob Access Key. Leave blank to use SAS URL
        valueFrom:
          secretKeyRef:
            name: azure-credentail-secrets
            key: AZUREBLOBSS_KEY
```

Gatling Operator use [rclone](https://rclone.org/) to access any Cloud Storages, and to know more on Azure Blob Storage access using rclone, please see [Authenticating with Azure Blob Storage](https://rclone.org/azureblob/#authenticating-with-azure-blob-storage)

### Testing

1. prepare Azure blob storage account and container for testing (here, I used `gatlingreport001` and `gatling-operator-reports` respectively)

2. configure cloud storage provider to use azure blob storage in gatling CR to test authentication pattern ( 1 ) above

> config/samples/gatling-operator_v1alpha1_gatling01.yaml

```yaml
 cloudStorageSpec:
    provider: "azure"
    bucket: "gatling-operator-reports"
    env:                                             
      - name: AZUREBLOB_ACCOUNT
        value: gatlingreport001  
      - name: AZUREBLOB_KEY
        value: xxxxxxxxxxxxxxxxxxxxxxxxxxx==
```

apply the manifest and see the result

```

# apply the manifest
kustomize build config/samples  | kubectl apply -f -

# check the gatling cr status
kubectl get gatling gatling-sample01 -o jsonpath='{@.status}' |jqresult
```

See the report URL
```
kubectl get gatling gatling-sample01 -o jsonpath='{@.status}' |jq

{
  "reportCompleted": true,
  "reportStoragePath": "az:gatling-operator-reports/gatling-sample01/953431934",
  "reportUrl": "https://gatlingreport001.blob.core.windows.net/gatling-operator-reports/gatling-sample01/953431932/index.html",
  "reporterJobName": "gatling-sample01-reporter",
  "reporterStartTime": 1661659345,
  "runnerCompleted": true,
  "runnerJobName": "gatling-sample01-runner",
  "runnerStartTime": 1661658938,
  "succeeded": 3
}
```

made it access to reportURL (azure blob storage URL) like this:

![Screen Shot 2022-08-28 at 13 05 45](https://user-images.githubusercontent.com/82332/187070061-312d0bf2-5698-4c7d-a69b-b8ff47057911.png)


3. prepare SAS URL for the azure blob storage to test authentication pattern ( 2 ) above


```yaml
 cloudStorageSpec:
   provider: "azure"
    bucket: "gatling-operator-reports" 
    env:
      - name: AZUREBLOB_SAS_URL
        value: "https://gatlingreport001.blob.core.windows.net/gatling-operator-reports?sp=rwl&st=2022-08-27T04:38:09Z&se=2022-09-01T12:38:09Z&spr=https&sv=2021-06-08&sr=c&sig=xGjILJf%2FJKZTPXXASIE5CAJa%2B6D%2BzO%2BJUWGthbjln5A%3D"
      - name: AZUREBLOB_ACCOUNT
        value: gatlingreport001
```

apply the manifest and see the result

```

# apply the manifest
kustomize build config/samples  | kubectl apply -f -

# check the gatling cr status
kubectl get gatling gatling-sample01 -o jsonpath='{@.status}' |jqresult
```

Likewise 2, made it access to reportURL (azure blob storage URL) !!


### Checklist

_Please check if applicable_

- [x] Tests have been added (if applicable, ie. when operator codes are added or modified)
- [x] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified) 
  - add API Docs
  - NOTE: relevant docs are not yet in  [User Guide](https://github.com/st-tech/gatling-operator/blob/main/docs/user-guide.md). It will be added in the next PR

<!--
  Make sure to link the related issue for this change
-->
Relevant issue #

https://github.com/st-tech/gatling-operator/issues/38