### PR TITLE
Increase default memory allocation for the Gatling manager 

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -48,9 +48,9 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 100Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Signed-off-by: Yoichi Kawasaki <yokawasa@gmail.com>

### Description

It has been observed that Gatling manager got stuck due to the lack of memory allocation. It's depends on how many parallel executions the Gatling manager handles but I found it reasonable to increase its memory  allocation from my experience. 
