### PR TITLE
Support Additional printer columns for Gatling CR

### DIFF
--- a/api/v1alpha1/gatling_types.go
+++ b/api/v1alpha1/gatling_types.go
@@ -21,9 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // GatlingSpec defines the desired state of Gatling
 type GatlingSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
@@ -200,6 +197,10 @@ type GatlingStatus struct {
 	// +optional
 	RunnerCompleted bool `json:"runnerCompleted,omitempty"`
 
+	// The number of successfully completed runner pods. The format is (completed#/parallelism#)
+	// +optional
+	RunnerCompletions string `json:"runnerCompletions,omitempty"`
+
 	// Reporter job name
 	// +optional
 	ReporterJobName string `json:"reporterJobName,omitempty"`
@@ -231,6 +232,11 @@ type GatlingStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Runned",type=string,JSONPath=`.status.runnerCompletions`
+//+kubebuilder:printcolumn:name="Reported",type=boolean,JSONPath=`.status.reportCompleted`
+//+kubebuilder:printcolumn:name="Notified",type=boolean,JSONPath=`.status.notificationCompleted`
+//+kubebuilder:printcolumn:name="ReportURL",type=string,JSONPath=`.status.reportUrl`
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Gatling is the Schema for the gatlings API
 type Gatling struct {

--- a/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
+++ b/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
@@ -16,7 +16,23 @@ spec:
     singular: gatling
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.runnerCompletions
+      name: Runned
+      type: string
+    - jsonPath: .status.reportCompleted
+      name: Reported
+      type: boolean
+    - jsonPath: .status.notificationCompleted
+      name: Notified
+      type: boolean
+    - jsonPath: .status.reportUrl
+      name: ReportURL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Gatling is the Schema for the gatlings API
@@ -1339,6 +1355,10 @@ spec:
               runnerCompleted:
                 description: Is runner job completed (default false)
                 type: boolean
+              runnerCompletions:
+                description: The number of successfully completed runner pods. The
+                  format is (completed#/parallelism#)
+                type: string
               runnerJobName:
                 description: Runner job name
                 type: string

--- a/controllers/gatling_controller.go
+++ b/controllers/gatling_controller.go
@@ -205,6 +205,7 @@ func (r *GatlingReconciler) gatlingRunnerReconcile(ctx context.Context, req ctrl
 		gatling.Status.Active = runnerJob.Status.Active
 		gatling.Status.Failed = runnerJob.Status.Failed
 		gatling.Status.Succeeded = runnerJob.Status.Succeeded
+		gatling.Status.RunnerCompletions = r.getRunnerCompletionsStatus(gatling)
 		gatling.Status.RunnerCompleted = false
 		gatling.Status.ReportCompleted = false
 		gatling.Status.NotificationCompleted = false
@@ -235,6 +236,7 @@ func (r *GatlingReconciler) gatlingRunnerReconcile(ctx context.Context, req ctrl
 	gatling.Status.Active = foundJob.Status.Active
 	gatling.Status.Failed = foundJob.Status.Failed
 	gatling.Status.Succeeded = foundJob.Status.Succeeded
+	gatling.Status.RunnerCompletions = r.getRunnerCompletionsStatus(gatling)
 
 	// Check if the job runs out of time in running the job
 	duration := utils.GetEpocTime() - gatling.Status.RunnerStartTime
@@ -838,10 +840,11 @@ func (r *GatlingReconciler) updateGatlingStatus(ctx context.Context, gatling *ga
 }
 
 func (r *GatlingReconciler) dumpGatlingStatus(gatling *gatlingv1alpha1.Gatling, log logr.Logger) {
-	log.Info(fmt.Sprintf("GatlingStatus: Active %d Succeeded %d Failed %d ReportCompleted %t NotificationCompleted %t ReportUrl %s Error %v",
+	log.Info(fmt.Sprintf("GatlingStatus: Active %d Succeeded %d Failed %d RunnerCompletions %s ReportCompleted %t NotificationCompleted %t ReportUrl %s Error %v",
 		gatling.Status.Active,
 		gatling.Status.Succeeded,
 		gatling.Status.Failed,
+		gatling.Status.RunnerCompletions,
 		gatling.Status.ReportCompleted,
 		gatling.Status.NotificationCompleted,
 		gatling.Status.ReportUrl,
@@ -1002,6 +1005,10 @@ func (r *GatlingReconciler) getGenerateLocalReport(gatling *gatlingv1alpha1.Gatl
 		return false
 	}
 	return gatling.Spec.GenerateLocalReport
+}
+
+func (r *GatlingReconciler) getRunnerCompletionsStatus(gatling *gatlingv1alpha1.Gatling) string {
+	return fmt.Sprintf("%d/%d", gatling.Status.Succeeded, *(r.getGatlingRunnerJobParallelism(gatling)))
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/docs/quickstart-guide.md
+++ b/docs/quickstart-guide.md
@@ -99,12 +99,12 @@ kubectl logs gatling-sample01-runner-tkplh -c gatling-runner -f
 Expected output would be like this:
 
 ```bash
-Wait until 2022-02-25 06:07:25
+Wait until 2022-11-28 00:34:56
 GATLING_HOME is set to /opt/gatling
 Simulation MyBasicSimulation started...
 
 ================================================================================
-2022-02-25 06:08:31                                           5s elapsed
+2022-11-28 00:37:17                                           5s elapsed
 ---- Requests ------------------------------------------------------------------
 > Global                                                   (OK=2      KO=0     )
 > request_1                                                (OK=1      KO=0     )
@@ -117,7 +117,7 @@ Simulation MyBasicSimulation started...
 
 
 ================================================================================
-2022-02-25 06:08:36                                          10s elapsed
+2022-11-28 00:37:22                                          10s elapsed
 ---- Requests ------------------------------------------------------------------
 > Global                                                   (OK=3      KO=0     )
 > request_1                                                (OK=1      KO=0     )
@@ -131,7 +131,7 @@ Simulation MyBasicSimulation started...
 
 
 ================================================================================
-2022-02-25 06:08:40                                          14s elapsed
+2022-11-28 00:37:27                                          14s elapsed
 ---- Requests ------------------------------------------------------------------
 > Global                                                   (OK=6      KO=0     )
 > request_1                                                (OK=1      KO=0     )
@@ -146,7 +146,7 @@ Simulation MyBasicSimulation started...
           waiting: 0      / active: 0      / done: 1
 ================================================================================
 
-Simulation MyBasicSimulation completed in 14 seconds
+Simulation MyBasicSimulation completed in 15 seconds
 ```
 
 As configured in [the sample manifest](https://github.com/st-tech/gatling-operator/blob/85e69840274214c47e63f65a5c807dd541dff245/config/samples/gatling-operator_v1alpha1_gatling01.yaml#L6-L8), an aggregated Gatling HTML report is not created, nor a notification message is posted.
@@ -206,11 +206,12 @@ kubectl get gatling gatling-sample01 -o jsonpath='{@.status}' |jq
   "reportStoragePath": "s3:gatling-operator-reports/gatling-sample01/318807881"
   "reportUrl": "https://gatling-operator-reports.s3.amazonaws.com/gatling-sample01/318807881/index.html"
   "reporterJobName": gatling-sample01-reporter
-  "reporterStartTime": 1631415671
-  "runnerCompleted": true
-  "runnerJobName": gatling-sample01-runner
-  "runnerStartTime": 1631415570
-  "succeeded": 5
+  "reporterStartTime": 1669595852,
+  "runnerCompleted": true,
+  "runnerCompletions": "3/3",
+  "runnerJobName": "gatling-sample01-runner",
+  "runnerStartTime": 1669595687,
+  "succeeded": 3
 }
 ```
 

--- a/docs/quickstart-guide.md
+++ b/docs/quickstart-guide.md
@@ -31,7 +31,7 @@ kind create cluster
 ## Install Gatling Operator
 
 ```bash
-kubectl apply -f https://github.com/st-tech/gatling-operator/releases/download/v0.5.0/gatling-operator.yaml
+kubectl apply -f https://github.com/st-tech/gatling-operator/releases/download/v0.9.0/gatling-operator.yaml
 ```
 
 Expected output would be like this:
@@ -49,7 +49,7 @@ deployment.apps/gatling-operator-controller-manager created
 
 All resources required for the Gatling operator, such as CRD and controller manager, are deployed using the command above. Now you're ready to deploy Gatling CR to run Gatling load testing.
 
-The command above applies a Gatling Operator manifest of v0.5.0. Please change the version if necessary. You can check the version from the [Release page](https://github.com/st-tech/gatling-operator/releases).
+The command above applies a Gatling Operator manifest of v0.9.0. Please change the version if necessary. You can check the version from the [Release page](https://github.com/st-tech/gatling-operator/releases).
 
 ## Run your first load testing by deploying Gatling CR
 
@@ -78,16 +78,16 @@ $ kubectl get gatling,job,pod
 Expected output would be like this:
 
 ```
-NAME                                                      AGE
-gatling.gatling-operator.tech.zozo.com/gatling-sample01   10s
+NAME                                                      RUNNED   REPORTED   NOTIFIED   REPORTURL                                                                                 AGE
+gatling.gatling-operator.tech.zozo.com/gatling-sample01   0/3                            https://gatling-operator-reports.s3.amazonaws.com/gatling-sample01/318807881/index.html   24s
 
 NAME                                COMPLETIONS   DURATION   AGE
-job.batch/gatling-sample01-runner   0/3           9s         9s
+job.batch/gatling-sample01-runner   0/3           24s        24s
 
 NAME                                READY   STATUS    RESTARTS   AGE
-pod/gatling-sample01-runner-8rhl4   1/1     Running   0          9s
-pod/gatling-sample01-runner-cg8rt   1/1     Running   0          9s
-pod/gatling-sample01-runner-tkplh   1/1     Running   0          9s
+pod/gatling-sample01-runner-8rhl4   2/2     Running   0          24s
+pod/gatling-sample01-runner-cg8rt   2/2     Running   0          24s
+pod/gatling-sample01-runner-tkplh   2/2     Running   0          24s
 ```
 
 You can also see from the Pod logs that Gatling is running.


### PR DESCRIPTION
### Description

Support Additional printer columns for Gatling CR so that  useful Gatling status will be displayed with `kubectl get gatling <name>` command

For example, currently `kubectl get gatling <name>` only display like this:

```bash
kubectl get gatling gatling-sample01

NAME               AGE
gatling-sample01   97m
```

With this update, `kubectl get gatling <name>` will display like this (more useful information for users):

```bash
NAME               RUNNED   REPORTED   NOTIFIED   REPORTURL                                                                                 AGE
gatling-sample01   3/3      true       true       https://my-test-report.s3.amazonaws.com/gatling-sample01/3499717572/index.html   3m50s
```

### Testing

#### case1: runner of parallelism 3 with no report + no notification pattern

1. prepare testing Gatling CR where reporting is enabled 

base gatling CR is [this]( https://github.com/st-tech/gatling-operator/blob/main/config/samples/gatling-operator_v1alpha1_gatling01.yaml). 

> config/samples/gatling-operator_v1alpha1_gatling01.yaml

```yaml
apiVersion: gatling-operator.tech.zozo.com/v1alpha1
kind: Gatling
metadata:
  name: gatling-sample01
spec:
  generateReport: false
  generateLocalReport: false
  notifyReport: false
  cleanupAfterJobDone: false
```

apply the manifest and see the result

```

# apply the manifest
kustomize build config/samples  | kubectl apply -f -

# check the gatling cr and it's status
kubectl get gatling gatling-sample01
kubectl get gatling gatling-sample01 -o jsonpath='{@.status}' |jq
```

Check if new additional printer columns are displayed
```
kubectl get gatling gatling-sample01

NAME               RUNNED   REPORTED   NOTIFIED   REPORTURL                                                                                 AGE
gatling-sample01   3/3                            https://my-test-reports-0001.s3.amazonaws.com/gatling-sample01/3499717572/index.html   2m59s
```

Check if `runnerCompletions` field is added in Gatling CR status 
```
kubectl get gatling gatling-sample01 -o jsonpath='{@.status}' |jq

{
  "reportStoragePath": "s3:my-test-reports-0001/gatling-sample01/3499717572",
  "reportUrl": "https://my-test-reports-0001.s3.amazonaws.com/gatling-sample01/3499717572/index.html",
  "reporterJobName": "gatling-sample01-reporter",
  "reporterStartTime": 1669533890,
  "runnerCompleted": true,
  "runnerCompletions": "3/3",
  "runnerJobName": "gatling-sample01-runner",
  "runnerStartTime": 1669533727,
  "succeeded": 3
}
```

#### case2: Runner of parallelism 3 with report + notification pattern

base gatling CR is [this]( https://github.com/st-tech/gatling-operator/blob/main/config/samples/gatling-operator_v1alpha1_gatling01.yaml). 

> config/samples/gatling-operator_v1alpha1_gatling01.yaml

```yaml
apiVersion: gatling-operator.tech.zozo.com/v1alpha1
kind: Gatling
metadata:
  name: gatling-sample01
spec:
  generateReport: true
  generateLocalReport: false
  notifyReport: true
  cleanupAfterJobDone: false
```

apply the manifest and see the result

```

# apply the manifest
kustomize build config/samples  | kubectl apply -f -

# check the gatling cr and it's status
kubectl get gatling gatling-sample01
kubectl get gatling gatling-sample01 -o jsonpath='{@.status}' |jq
```

Check if new additional printer columns are displayed

```
kubectl get gatling gatling-sample01

NAME               RUNNED   REPORTED   NOTIFIED   REPORTURL                                                                                 AGE
gatling-sample01   3/3      true       true       https://my-test-report-0001.s3.amazonaws.com/gatling-sample01/3499717572/index.html   3m50s
```
Check if `runnerCompletions` field is added in Gatling CR status 

```
kubectl get gatling gatling-sample01 -o jsonpath='{@.status}' |jq

{
  "reportCompleted": true,
  "reportStoragePath": "s3:my-gatling-reports-0001/gatling-sample01/3499717572",
  "reportUrl": "https://my-gatling-reports-0001.s3.amazonaws.com/gatling-sample01/3499717572/index.html",
  "reporterJobName": "gatling-sample01-reporter",
  "reporterStartTime": 1669533890,
  "runnerCompleted": true,
  "runnerCompletions": "3/3",
  "runnerJobName": "gatling-sample01-runner",
  "runnerStartTime": 1669533727,
  "NotificationCompleted": true,
  "succeeded": 3
}
```


### Checklist

_Please check if applicable_

- [x] Tests have been added  NOTE no test code added for now as it's the command output need to be checked in client side, but it'll be added when e2e tests are added
- [x] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified)

<!--
  Make sure to link the related issue for this change
-->
Relevant issue #

https://github.com/st-tech/gatling-operator/issues/50
