### PR TITLE
Report Viewer Starting Point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dylib
 bin
 testbin/*
+.DS_Store
 
 # Test binary, build with `go test -c`
 *.test

--- a/config/samples/report-viewer.yaml
+++ b/config/samples/report-viewer.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: report-viewer-nginx-configmap
+  labels:
+    app: report-viewer
+data:
+  nginx.conf: |-
+    worker_processes 1;
+    error_log stderr;
+    daemon off;
+    pid nginx.pid;
+
+    events {
+      worker_connections  1024;
+    }
+
+    http {
+      include             /etc/nginx/mime.types;
+      default_type        application/octet-stream;
+
+      sendfile on;
+
+      keepalive_timeout   65;
+
+      ssl_protocols TLSv1 TLSv1.1 TLSv1.2; 
+      ssl_prefer_server_ciphers on;
+      access_log access.log;
+      server {
+        listen 8088;
+        server_name localhost;
+
+        root /opt/gatling;
+        index index.html;
+
+        location / {
+                try_files $uri $uri/ =404;
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: report-viewer
+  name: report-viewer-service
+spec:
+  ports:
+    - name: "8080"
+      port: 8080
+      targetPort: 8088
+  selector:
+    app: report-viewer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: report-viewer
+spec:
+  selector:
+    matchLabels:
+      app: report-viewer
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: report-viewer
+    spec:
+      containers:
+      - image: gatling:local
+        imagePullPolicy: Never
+        name: report-viewer
+        command: [ "/bin/bash", "-c", ]
+        args:
+          - aws s3 sync s3://$S3_BUCKET_NAME /opt/gatling/results;
+            gatling.sh -ro /opt/gatling;
+            nginx -c /opt/gatling/etc/nginx/nginx.conf;
+        volumeMounts:
+          - mountPath: /opt/gatling/etc/nginx
+            name: report-viewer-nginx-volume
+        env:
+          - name: S3_BUCKET_NAME
+            value: gatling-operator-reports
+          - name: AWS_ACCESS_KEY_ID
+            value: xxxxxxxxxxxxxxx
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: aws-credentials-secret
+                key: AWS_SECRET_ACCESS_KEY
+        ports:
+          - containerPort: 8088
+            name: http
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "4G"
+          limits:
+            cpu: "2"
+            memory: "4G"
+      volumes:
+        - name: report-viewer-nginx-volume
+          configMap:
+            name: report-viewer-nginx-configmap

--- a/gatling/Dockerfile
+++ b/gatling/Dockerfile
@@ -6,26 +6,35 @@
 # Documentation: https://gatling.io/docs/3.2/
 # Cheat sheet: https://gatling.io/docs/3.2/cheat-sheet/
 
-FROM openjdk:8-jdk-alpine
+FROM public.ecr.aws/docker/library/eclipse-temurin:8-jdk-jammy
 
 # working directory for gatling
 WORKDIR /opt
 
 # gating version
 ENV GATLING_VERSION 3.2.1
-
-# create directory for gatling install
-RUN mkdir -p gatling
+ENV APP_HOME  /opt/gatling
+ENV APP_USER  gatling
+ENV APP_GROUP appgroup
 
 # install gatling
-RUN apk add --update wget bash libc6-compat && \
+RUN set -x && mkdir -p gatling && \
+  apt-get update && \
+  apt-get -y upgrade && \
+  apt-get install -y --no-install-recommends curl wget libc6 unzip awscli nginx && \
   mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \
   unzip /tmp/downloads/gatling-$GATLING_VERSION.zip && \
   mv /tmp/archive/gatling-charts-highcharts-bundle-$GATLING_VERSION/* /opt/gatling/ && \
-  rm -rf /opt/gatling/user-files/simulations/computerdatabase /tmp/*
+  rm -rf /opt/gatling/user-files/simulations/computerdatabase /tmp/* && \
+  addgroup --system ${APP_GROUP} && \
+  adduser --system ${APP_USER} --ingroup ${APP_GROUP} --home ${APP_HOME} --no-create-home && \
+  chown -R ${APP_USER}:${APP_GROUP} ${APP_HOME} && \
+  chown -R ${APP_USER}:${APP_GROUP} /var/log/nginx /var/lib/nginx /usr/share/nginx
+
+USER gatling
 
 # change context to gatling directory
 WORKDIR  /opt/gatling


### PR DESCRIPTION
### Description

Moved from alpine to ubuntu and temurin JDK
Running gatling and report-viewer as a `gatling` user instead of `root`
Added awscli, ngninx, unzip, and curl dependencies
Added report-viewer.yaml, which defines a configmap for nginx.conf and report-viewer deployment/service

Should the gatling and report-viewer images be separate images? I would imagine the report viewer should really have its own CRD and be managed by the operator. I just saw this as a quick alternative. I also should have looked into using `rclone` instead of the awscli. This is by no means considered done, I just wanted to submit the PR and get feedback. Thanks for creating this operator!

#### Port-forward to the report-viewer
`kpf $(kgp -l app=report-viewer --no-headers -o custom-columns=":metadata.name") 8088`

### Checklist

_Please check if applicable_

- [ ] Tests have been added (if applicable, ie. when operator codes are added or modified)
- [ ] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified)

Resolves #73
