### PR TITLE
Fixed to be able to get xx_wait_time from environment variable

### DIFF
--- a/controllers/gatling_controller.go
+++ b/controllers/gatling_controller.go
@@ -217,8 +217,9 @@ func (r *GatlingReconciler) gatlingRunnerReconcile(ctx context.Context, req ctrl
 	err := r.Get(ctx, client.ObjectKey{Name: gatling.Status.RunnerJobName, Namespace: req.Namespace}, foundJob)
 	if err != nil && apierr.IsNotFound(err) {
 		duration := utils.GetEpocTime() - gatling.Status.RunnerStartTime
-		if duration > maxJobCreationWaitTimeInSeconds {
-			msg := fmt.Sprintf("Runs out of time (%d sec) in creating the runner job", maxJobCreationWaitTimeInSeconds)
+		maxCreationWaitTIme := int32(utils.GetNumEnv("MAX_JOB_CREATION_WAIT_TIME", maxJobCreationWaitTimeInSeconds))
+		if duration > maxCreationWaitTIme {
+			msg := fmt.Sprintf("Runs out of time (%d sec) in creating the runner job", maxCreationWaitTIme)
 			log.Error(err, msg, "namespace", req.Namespace, "name", gatling.Status.RunnerJobName)
 			gatling.Status.Error = msg
 			if err := r.updateGatlingStatus(ctx, gatling); err != nil {
@@ -240,8 +241,9 @@ func (r *GatlingReconciler) gatlingRunnerReconcile(ctx context.Context, req ctrl
 
 	// Check if the job runs out of time in running the job
 	duration := utils.GetEpocTime() - gatling.Status.RunnerStartTime
-	if duration > maxJobRunWaitTimeInSeconds {
-		msg := fmt.Sprintf("Runs out of time (%d sec) in running the runner job", maxJobCreationWaitTimeInSeconds)
+	maxRunWaitTIme := int32(utils.GetNumEnv("MAX_JOB_RUN_WAIT_TIME", maxJobRunWaitTimeInSeconds))
+	if duration > maxRunWaitTIme {
+		msg := fmt.Sprintf("Runs out of time (%d sec) in running the runner job", maxRunWaitTIme)
 		log.Error(nil, msg, "namespace", req.Namespace, "name", gatling.Status.ReporterJobName)
 		gatling.Status.Error = msg
 		if err := r.updateGatlingStatus(ctx, gatling); err != nil {
@@ -317,8 +319,9 @@ func (r *GatlingReconciler) gatlingReporterReconcile(ctx context.Context, req ct
 	if err != nil && apierr.IsNotFound(err) {
 		// Check if the job runs out of time in creating the job
 		duration := utils.GetEpocTime() - gatling.Status.ReporterStartTime
-		if duration > maxJobCreationWaitTimeInSeconds {
-			msg := fmt.Sprintf("Runs out of time (%d sec) in creating the reporter job", maxJobCreationWaitTimeInSeconds)
+		maxCreationWaitTIme := int32(utils.GetNumEnv("MAX_JOB_CREATION_WAIT_TIME", maxJobCreationWaitTimeInSeconds))
+		if duration > maxCreationWaitTIme {
+			msg := fmt.Sprintf("Runs out of time (%d sec) in creating the reporter job", maxCreationWaitTIme)
 			log.Error(err, msg, "namespace", req.Namespace, "name", gatling.Status.ReporterJobName)
 			gatling.Status.Error = msg
 			if err := r.updateGatlingStatus(ctx, gatling); err != nil {
@@ -334,8 +337,9 @@ func (r *GatlingReconciler) gatlingReporterReconcile(ctx context.Context, req ct
 	}
 	// Check if the job runs out of time in running the job
 	duration := utils.GetEpocTime() - gatling.Status.ReporterStartTime
-	if duration > maxJobRunWaitTimeInSeconds {
-		msg := fmt.Sprintf("Runs out of time (%d sec) in running the reporter job, and no longer requeue", maxJobCreationWaitTimeInSeconds)
+	maxRunWaitTIme := int32(utils.GetNumEnv("MAX_JOB_RUN_WAIT_TIME", maxJobRunWaitTimeInSeconds))
+	if duration > maxRunWaitTIme {
+		msg := fmt.Sprintf("Runs out of time (%d sec) in running the reporter job, and no longer requeue", maxRunWaitTIme)
 		log.Error(nil, msg, "namespace", req.Namespace, "name", gatling.Status.ReporterJobName)
 		gatling.Status.Error = msg
 		if err := r.updateGatlingStatus(ctx, gatling); err != nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,7 +1,10 @@
 package utils
 
 import (
+	"fmt"
 	"hash/fnv"
+	"os"
+	"strconv"
 	"time"
 )
 
@@ -35,4 +38,17 @@ func AddMapValue(key string, value string, dataMap map[string]string, overwrite 
 	dataMap[key] = value
 	return dataMap
 
+}
+
+func GetNumEnv(key string, defaultValue int) int {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	valueNum, err := strconv.Atoi(value)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ENV '%s' is not valid\n", key)
+		return defaultValue
+	}
+	return valueNum
 }


### PR DESCRIPTION
### Description

The following constants can now be set as environment variables

- maxJobCreationWaitTimeInSeconds
- maxJobRunWaitTimeInSeconds

### Checklist

_Please check if applicable_

- [x] Tests have been added (if applicable, ie. when operator codes are added or modified)
- [ ] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified)

<!--
  Make sure to link the related issue for this change
-->
Relevant issue #

https://github.com/st-tech/gatling-operator/issues/76