### PR TITLE
Changes to fix container exit status

### DIFF
--- a/controllers/gatling_controller.go
+++ b/controllers/gatling_controller.go
@@ -441,6 +441,8 @@ func (r *GatlingReconciler) newGatlingRunnerJobForCR(gatling *gatlingv1alpha1.Ga
 		r.getGenerateLocalReport(gatling))
 	log.Info("gatlingRunnerCommand:", "comand", gatlingRunnerCommand)
 
+	var noRestarts int32 = 0
+
 	envVars := gatling.Spec.TestScenarioSpec.Env
 	if gatling.Spec.GenerateReport {
 		gatlingTransferResultCommand := commands.GetGatlingTransferResultCommand(
@@ -457,6 +459,7 @@ func (r *GatlingReconciler) newGatlingRunnerJobForCR(gatling *gatlingv1alpha1.Ga
 				Labels:    labels,
 			},
 			Spec: batchv1.JobSpec{
+				BackoffLimit: &noRestarts,
 				Parallelism: r.getGatlingRunnerJobParallelism(gatling),
 				Completions: r.getGatlingRunnerJobParallelism(gatling),
 				Template: corev1.PodTemplateSpec{
@@ -523,6 +526,7 @@ func (r *GatlingReconciler) newGatlingRunnerJobForCR(gatling *gatlingv1alpha1.Ga
 			Labels:    labels,
 		},
 		Spec: batchv1.JobSpec{
+			BackoffLimit: &noRestarts,
 			Parallelism: &gatling.Spec.TestScenarioSpec.Parallelism,
 			Completions: &gatling.Spec.TestScenarioSpec.Parallelism,
 			Template: corev1.PodTemplateSpec{

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -68,11 +68,13 @@ if [ ! -d ${RESULTS_DIR_PATH} ]; then
 fi
 gatling.sh -sf ${SIMULATIONS_DIR_PATH} -s %s -rsf ${RESOURCES_DIR_PATH} -rf ${RESULTS_DIR_PATH} %s
 
-if [ $? -ne 0 ]; then
+GATLING_EXIT_STATUS=$?
+if [ $GATLING_EXIT_STATUS -ne 0 ]; then
   RUN_STATUS_FILE="${RESULTS_DIR_PATH}/FAILED"
   echo "gatling.sh has failed!" 1>&2
 fi
 touch ${RUN_STATUS_FILE}
+exit $GATLING_EXIT_STATUS
 `
 	generateLocalReportOption := "-nr"
 	if generateLocalReport {


### PR DESCRIPTION
### Description

The Gatling exit status was getting overwritten by another command running after Gatling's process finished. This PR ensure the GATLING_EXIT_STATUS is returned. This exposed another issue where Kubernetes re-runs failed jobs. In this case, we actually don't want failed jobs to re-run. In order to fix this, I set the `BackoffLimit` to 0 so the pods won't get recreated.

Resolves #81