### PR TITLE
Update go version to 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.21'
 
       - run: go version
 
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.21'
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.21-bullseye as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ENV GO_VERSION 1.17.13
+ENV GO_VERSION 1.21.7
 ENV KUBECTL_VERSION v1.21.10
 
 # KEEP the value as arm64.
@@ -12,26 +12,26 @@ ENV ETCD_UNSUPPORTED_ARCH arm64
 
 # Development tools
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
-        wget \
-        git \
-        make \
-        gcc
+    wget \
+    git \
+    make \
+    gcc
 
 # Docker CLI
 # Referring to https://docs.docker.com/engine/install/ubuntu/#installation-methods
 RUN apt-get install -y \
-        ca-certificates \
-        curl \
-        gnupg \
+    ca-certificates \
+    curl \
+    gnupg \
     && install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
-        | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
     && chmod a+r /etc/apt/keyrings/docker.gpg \
     && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-        "$(. /etc/os-release && echo "${VERSION_CODENAME}")" stable" \
-        | tee /etc/apt/sources.list.d/docker.list > /dev/null \
+    "$(. /etc/os-release && echo "${VERSION_CODENAME}")" stable" \
+    | tee /etc/apt/sources.list.d/docker.list > /dev/null \
     && apt-get update && apt-get install -y \
-        docker-ce-cli
+    docker-ce-cli
 
 # kubectl
 # Referring to https://kubernetes.io/ja/docs/tasks/tools/install-kubectl/

--- a/Makefile
+++ b/Makefile
@@ -138,26 +138,26 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5@v5.3.0)
 
 CRD_REF_DOCS = $(shell pwd)/bin/crd-ref-docs
 crd-ref-docs: ## Download crd-ref-docs locally if necessary.
-	$(call go-get-tool,$(CRD_REF_DOCS),github.com/elastic/crd-ref-docs@master)
+	$(call go-install-tool,$(CRD_REF_DOCS),github.com/elastic/crd-ref-docs@master)
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
+# go-install-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-define go-get-tool
+define go-install-tool
 @[ -f $(1) ] || { \
 set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/docs/build-guide.md
+++ b/docs/build-guide.md
@@ -27,7 +27,6 @@ git clone https://github.com/st-tech/gatling-operator
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
 - [go](https://go.dev/doc/install)
-  - go version must be 1.17
 
 ## Create a Kubernetes cluster
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/st-tech/gatling-operator
 
-go 1.17
+go 1.21
 
 require (
 	github.com/go-logr/logr v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -87,7 +87,6 @@ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2y
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=


### PR DESCRIPTION
### Description
The previous PR for updating go was reverted since the ci failed.
https://github.com/st-tech/gatling-operator/pull/107

This PR is a revenge of it.
I added to fix the version of `sigs.k8s.io/kustomize/kustomize` from `v3@v3.8.7` to `v5@v5.3.0` which is the latest.
I assume that the old kustomize used exclude directive is a reason.
https://github.com/kubernetes-sigs/kustomize/blob/kustomize/v3.8.7/kustomize/go.mod

Confirmed the make command works correctly.

```
% make manifests-release
/Users/koki.hatano/github/gold-kou/gatling-operator/bin/controller-gen "crd:trivialVersions=true,preserveUnknownFields=false" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
cd config/manager && /Users/koki.hatano/github/gold-kou/gatling-operator/bin/kustomize edit set image controller=gatling-operator:20240301-143405
/Users/koki.hatano/github/gold-kou/gatling-operator/bin/kustomize build config/default > gatling-operator.yaml
```

The other changes are same with https://github.com/st-tech/gatling-operator/pull/105 .

### Checklist

_Please check if applicable_

- [ ] Tests have been added (if applicable, ie. when operator codes are added or modified)
- [x] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified)

<!--
  Make sure to link the related issue for this change
-->
Relevant issue #
