### PR TITLE
[vul-scan] Avoid creating security alert issue when there are no vulnerabilities

### DIFF
--- a/.github/ISSUE_TEMPLATE/trivy-results.tpl
+++ b/.github/ISSUE_TEMPLATE/trivy-results.tpl
@@ -1,4 +1,4 @@
-{{ $d := dict "CRITICAL" "🔴" "HIGH" "🟠" "MEDIUM" "🟡" "UNKNOWN" "🟤" }}
+{{- $severity_icon := dict "CRITICAL" "🔴" "HIGH" "🟠" "MEDIUM" "🟡" "UNKNOWN" "🟤" -}}
 
 {{- range . -}}
 ## {{ .Target }}
@@ -10,7 +10,7 @@
 | :--: | :--: | :--: | :--: | :--: | :--: | :-- |
 {{- range .Vulnerabilities }}
 | {{ .Title -}}
-| {{ get $d .Severity }}{{ .Severity -}}
+| {{ get $severity_icon .Severity }}{{ .Severity -}}
 | {{ .VulnerabilityID -}}
 | {{ .PkgName -}}
 | {{ .InstalledVersion -}}

--- a/.github/ISSUE_TEMPLATE/trivy-results.tpl
+++ b/.github/ISSUE_TEMPLATE/trivy-results.tpl
@@ -1,4 +1,5 @@
 {{- $severity_icon := dict "CRITICAL" "🔴" "HIGH" "🟠" "MEDIUM" "🟡" "UNKNOWN" "🟤" -}}
+{{- $vulns_count := 0 }}
 
 {{- range . -}}
 ## {{ .Target }}
@@ -17,6 +18,7 @@
 | {{ .FixedVersion -}}
 | {{ .PrimaryURL -}}
 |
+{{- $vulns_count = add1 $vulns_count -}}
 {{- end }}
 
 {{ else -}}
@@ -25,3 +27,5 @@ _No vulnerabilities found_
 {{ end }}
 
 {{- end }}
+---
+**Total count of vulnerabilities: {{ $vulns_count }}**

--- a/.github/workflows/daily-vul-scan.yml
+++ b/.github/workflows/daily-vul-scan.yml
@@ -37,7 +37,7 @@ jobs:
           make docker-build IMG="${{ env.IMAGE_NAME }}:${{ github.sha }}"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.18.0
         with:
           scan-type: image
           image-ref: "${{ env.IMAGE_NAME }}:${{ github.sha }}"

--- a/.github/workflows/daily-vul-scan.yml
+++ b/.github/workflows/daily-vul-scan.yml
@@ -51,8 +51,21 @@ jobs:
           template: "@.github/ISSUE_TEMPLATE/trivy-results.tpl"
           output: ${{ env.TRIVY_RESULTS_MARKDOWN }}
 
+      - name: Extract total count of vulnerabilities
+        id: extract-total-cnt-of-vulns
+        run: |
+          if [[ $(cat "${{ env.TRIVY_RESULTS_MARKDOWN }}") =~ Total\ count\ of\ vulnerabilities:\ ([0-9]+) ]]; then
+            result=${BASH_REMATCH[0]}
+            echo "$result"
+            total_cnt_of_vulns=${BASH_REMATCH[1]}
+            echo "total_cnt_of_vulns=$total_cnt_of_vulns" >> "$GITHUB_OUTPUT"
+          else
+            echo "Error: Failed to extract total count of vulnerabilities"
+            exit 1
+          fi
+
       - name: Insert YAML front matter into the results markdown
-        if: always()
+        if: ${{ fromJson(steps.extract-total-cnt-of-vulns.outputs.total_cnt_of_vulns) > 0 }}
         run: |
           sed -i '1i\
           ---\
@@ -62,8 +75,8 @@ jobs:
           ' "${{ env.TRIVY_RESULTS_MARKDOWN }}"
 
       - name: Create or update the trivy results issue
+        if: ${{ fromJson(steps.extract-total-cnt-of-vulns.outputs.total_cnt_of_vulns) > 0 }}
         uses: JasonEtco/create-an-issue@v2
-        if: always()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/daily-vul-scan.yml
+++ b/.github/workflows/daily-vul-scan.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           scan-type: image
           image-ref: "${{ env.IMAGE_NAME }}:${{ github.sha }}"
-          exit-code: 1
+          exit-code: 0
           ignore-unfixed: true
           vuln-type: os,library
           severity: HIGH,CRITICAL

--- a/.github/workflows/daily-vul-scan.yml
+++ b/.github/workflows/daily-vul-scan.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           sed -i '1i\
           ---\
-          title: "[DO NOT CHANGE] Security Alert"\
+          title: "Security Alert by Trivy"\
           labels: "trivy, vulnerability"\
           ---\
           ' "${{ env.TRIVY_RESULTS_MARKDOWN }}"


### PR DESCRIPTION
### Description

Is there any significance in creating an issue to report that there are no vulnerabilities? (I've created this workflow :cry: )
No, it's not. Therefore, I implemented the following changes.

Modify the `daily-vul-scan.yml` to avoid creating security alert issue when no vulnerabilities are found.
* 529eed5
  *  Add extracting total count of vulnerabilities to determine whether to create an issue.
  *  Add conditions to subsequent steps.
* 5d40c79
  * Change `exit-code` to 0 to ensure the workflow does not stop.
* some small changes

Here are the test results.
1. with vulnerabilities
https://github.com/R-HNF/gatling-operator/actions/runs/8339157882/job/22820651285
<img width="1142" alt="スクリーンショット 2024-03-19 16 55 33" src="https://github.com/st-tech/gatling-operator/assets/15979860/a83bfe93-1720-499c-a12f-5d9c5fa191e3">

2. without vulnerabilities
https://github.com/R-HNF/gatling-operator/actions/runs/8339086656/job/22820455755
<img width="1142" alt="スクリーンショット 2024-03-19 16 55 41" src="https://github.com/st-tech/gatling-operator/assets/15979860/879fe702-7f36-4572-8ad8-b5ffd8969b10">


### Checklist

Skip this checklist for CI changes.

- [ ] Tests have been added (if applicable, ie. when operator codes are added or modified)
- [ ] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified)

<!--
  Make sure to link the related issue for this change
-->
Relevant issue #45 
