### PR TITLE
feat: multiplatform build setup - linux/arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,11 @@ jobs:
           echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
           echo ::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Create release YAML (gatling-operator.yaml)
         env:

--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,8 @@ run: manifests generate fmt vet ## Run a controller from your host.
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
 
-docker-push: docker-build ## Push docker image with the manager.
-	docker push ${IMG}
+docker-push: test ## Push docker image with the manager.
+	docker buildx build --platform linux/amd64,linux/arm64 -t ${IMG} . --push
 
 kind-load-image: kind-create docker-build ## Load local docker image into the kind cluster
 	@echo "Loading image into kind"

--- a/controllers/gatling_controller.go
+++ b/controllers/gatling_controller.go
@@ -464,8 +464,8 @@ func (r *GatlingReconciler) newGatlingRunnerJobForCR(gatling *gatlingv1alpha1.Ga
 			},
 			Spec: batchv1.JobSpec{
 				BackoffLimit: &noRestarts,
-				Parallelism: r.getGatlingRunnerJobParallelism(gatling),
-				Completions: r.getGatlingRunnerJobParallelism(gatling),
+				Parallelism:  r.getGatlingRunnerJobParallelism(gatling),
+				Completions:  r.getGatlingRunnerJobParallelism(gatling),
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        r.getObjectMeta(gatling).Name,
@@ -479,7 +479,7 @@ func (r *GatlingReconciler) newGatlingRunnerJobForCR(gatling *gatlingv1alpha1.Ga
 						InitContainers: []corev1.Container{
 							{
 								Name:      "gatling-waiter",
-								Image:     "bitnami/kubectl:1.21.8",
+								Image:     "bitnami/kubectl:1.29.3",
 								Command:   []string{"/bin/sh", "-c"},
 								Args:      []string{gatlingWaiterCommand},
 								Resources: r.getPodResources(gatling),
@@ -531,8 +531,8 @@ func (r *GatlingReconciler) newGatlingRunnerJobForCR(gatling *gatlingv1alpha1.Ga
 		},
 		Spec: batchv1.JobSpec{
 			BackoffLimit: &noRestarts,
-			Parallelism: &gatling.Spec.TestScenarioSpec.Parallelism,
-			Completions: &gatling.Spec.TestScenarioSpec.Parallelism,
+			Parallelism:  &gatling.Spec.TestScenarioSpec.Parallelism,
+			Completions:  &gatling.Spec.TestScenarioSpec.Parallelism,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        r.getObjectMeta(gatling).Name,
@@ -546,7 +546,7 @@ func (r *GatlingReconciler) newGatlingRunnerJobForCR(gatling *gatlingv1alpha1.Ga
 					InitContainers: []corev1.Container{
 						{
 							Name:      "gatling-waiter",
-							Image:     "bitnami/kubectl:1.21.8",
+							Image:     "bitnami/kubectl:1.29.3",
 							Command:   []string{"/bin/sh", "-c"},
 							Args:      []string{gatlingWaiterCommand},
 							Resources: r.getPodResources(gatling),


### PR DESCRIPTION
### Description

I couldn't run your operator on the EKS with ARM nodes, but I've managed to build the image locally with `linux/armd64` target platform.  I had to upgrade `bitnami/kubectl:1.21.8` as well, because it was not supporting multiplatform builds: right now it does. 

It's my first contribution to the project, so please check the changes carefully. 

Is there any chance to get this reviewed, merged and released anytime soon? @gold-kou @R-HNF 

### Checklist

_Please check if applicable_

- [ ] Tests have been added (if applicable, ie. when operator codes are added or modified)
- [ ] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified)

<!--
  Make sure to link the related issue for this change
-->
Might be related to https://github.com/st-tech/gatling-operator/issues/74
