### PR TITLE
feat: simulations format

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ The desired state of a distributed Gatling load testing is described through a K
 
 ## Features
 
-- Allows Gatling load testing scenario, resources, Gatling configurations files to be added in 2 ways:
+- Allows Gatling load testing scenario, resources, Gatling configurations files to be added in 3 ways:
   - Bundle them with Gatling runtime packages in a Gatling container
+  - Run the simulations through build tool plugin (e.g. `gradle gatlingRun`) in a Docker container  
   - Add them as multi-line definition in Gatling CR
 - Scaling Gatling load testing
   - Horizontal scaling: number of pods running in parallel during a load testing can be configured

--- a/api/v1alpha1/gatling_types.go
+++ b/api/v1alpha1/gatling_types.go
@@ -116,6 +116,7 @@ type TestScenarioSpec struct {
 
 	// (Optional) Gatling simulation format, supports `bundle` and `gradle`. Defaults to `bundle`
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=bundle;gradle
 	SimulationsFormat string `json:"simulationsFormat,omitempty"`
 
 	// (Optional) Gatling Resources directory path where simulation files are stored. Defaults to `/opt/gatling/user-files/simulations`

--- a/api/v1alpha1/gatling_types.go
+++ b/api/v1alpha1/gatling_types.go
@@ -114,6 +114,10 @@ type TestScenarioSpec struct {
 	// +kubebuilder:validation:Optional
 	Parallelism int32 `json:"parallelism,omitempty"`
 
+	// (Optional) Gatling simulation format, supports `bundle` and `gradle`. Defaults to `bundle`
+	// +kubebuilder:validation:Optional
+	SimulationsFormat string `json:"simulationsFormat,omitempty"`
+
 	// (Optional) Gatling Resources directory path where simulation files are stored. Defaults to `/opt/gatling/user-files/simulations`
 	// +kubebuilder:validation:Optional
 	SimulationsDirectoryPath string `json:"simulationsDirectoryPath,omitempty"`

--- a/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
+++ b/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
@@ -4096,6 +4096,10 @@ spec:
                     description: (Optional) Gatling Resources directory path where
                       simulation files are stored. Defaults to `/opt/gatling/user-files/simulations`
                     type: string
+                  simulationsFormat:
+                    description: (Optional) Gatling simulation format, supports `bundle`
+                      and `gradle`. Defaults to `bundle`
+                    type: string
                   startTime:
                     description: (Optional) Test Start time.
                     type: string

--- a/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
+++ b/config/crd/bases/gatling-operator.tech.zozo.com_gatlings.yaml
@@ -4099,6 +4099,9 @@ spec:
                   simulationsFormat:
                     description: (Optional) Gatling simulation format, supports `bundle`
                       and `gradle`. Defaults to `bundle`
+                    enum:
+                    - bundle
+                    - gradle
                     type: string
                   startTime:
                     description: (Optional) Test Start time.

--- a/controllers/gatling_controller.go
+++ b/controllers/gatling_controller.go
@@ -49,6 +49,7 @@ const (
 	maxJobRunWaitTimeInSeconds         = 10800 // 10800 sec (3 hours)
 	defaultGatlingImage                = "ghcr.io/st-tech/gatling:latest"
 	defaultRcloneImage                 = "rclone/rclone:latest"
+	defaultSimulationFormat            = "bundle"
 	defaultSimulationsDirectoryPath    = "/opt/gatling/user-files/simulations"
 	defaultResourcesDirectoryPath      = "/opt/gatling/user-files/resources"
 	defaultResultsDirectoryPath        = "/opt/gatling/results"
@@ -521,6 +522,7 @@ func (r *GatlingReconciler) newGatlingRunnerJobForCR(gatling *gatlingv1alpha1.Ga
 	)
 
 	gatlingRunnerCommand := commands.GetGatlingRunnerCommand(
+		r.getSimulationFormat(gatling),
 		r.getSimulationsDirectoryPath(gatling),
 		r.getTempSimulationsDirectoryPath(gatling),
 		r.getResourcesDirectoryPath(gatling),
@@ -1070,6 +1072,14 @@ func (r *GatlingReconciler) getPodServiceAccountName(gatling *gatlingv1alpha1.Ga
 		serviceAccountName = gatling.Spec.PodSpec.ServiceAccountName
 	}
 	return serviceAccountName
+}
+
+func (r *GatlingReconciler) getSimulationFormat(gatling *gatlingv1alpha1.Gatling) string {
+	format := defaultSimulationFormat
+	if &gatling.Spec.TestScenarioSpec != nil && gatling.Spec.TestScenarioSpec.SimulationsFormat != "" {
+		format = gatling.Spec.TestScenarioSpec.SimulationsFormat
+	}
+	return format
 }
 
 func (r *GatlingReconciler) getSimulationsDirectoryPath(gatling *gatlingv1alpha1.Gatling) string {

--- a/docs/api.md
+++ b/docs/api.md
@@ -145,18 +145,19 @@ TestScenarioSpec defines the load testing scenario
 _Appears in:_
 - [GatlingSpec](#gatlingspec)
 
-| Field | Description |
-| --- | --- |
-| `startTime` _string_ | (Optional) Test Start time. |
-| `parallelism` _integer_ | (Optional) Number of pods running at the same time. Defaults to `1` (Minimum `1`) |
-| `simulationsDirectoryPath` _string_ | (Optional) Gatling Resources directory path where simulation files are stored. Defaults to `/opt/gatling/user-files/simulations` |
-| `resourcesDirectoryPath` _string_ | (Optional) Gatling Simulation directory path where resources are stored. Defaults to `/opt/gatling/user-files/resources` |
-| `resultsDirectoryPath` _string_ | (Optional) Gatling Results directory path where results are stored. Defaults to `/opt/gatling/results` |
-| `simulationClass` _string_ | (Required) Simulation Class Name. |
-| `simulationData` _object (keys:string, values:string)_ | (Optional) Simulation Data. |
-| `resourceData` _object (keys:string, values:string)_ | (Optional) Resource Data. |
-| `gatlingConf` _object (keys:string, values:string)_ | (Optional) Gatling Configurations. |
-| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#envvar-v1-core) array_ | (Optional) Environment variables used for running load testing scenario. |
-| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#volumemount-v1-core) array_ | (Optional) Pod volumes to mount into the container's filesystem. |
+| Field                                                                                                                          | Description                                                                                                                                                                                             |
+|--------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `startTime` _string_                                                                                                           | (Optional) Test Start time.                                                                                                                                                                             |
+| `parallelism` _integer_                                                                                                        | (Optional) Number of pods running at the same time. Defaults to `1` (Minimum `1`)                                                                                                                       |
+| `simulationFormat` _string_                                                                                                    | (Optional) Simulation format, should be one of `bundle` / `gradle`. Defaults to `bundle`. In case `gradle` one is chosen, all bundle-specific properties (e.g. `simulationsDirectoryPath`) are ignored. |
+| `simulationsDirectoryPath` _string_                                                                                            | (Optional) Gatling Resources directory path where simulation files are stored. Defaults to `/opt/gatling/user-files/simulations`                                                                        |
+| `resourcesDirectoryPath` _string_                                                                                              | (Optional) Gatling Simulation directory path where resources are stored. Defaults to `/opt/gatling/user-files/resources`                                                                                |
+| `resultsDirectoryPath` _string_                                                                                                | (Optional) Gatling Results directory path where results are stored. Defaults to `/opt/gatling/results`                                                                                                  |
+| `simulationClass` _string_                                                                                                     | (Required) Simulation Class Name.                                                                                                                                                                       |
+| `simulationData` _object (keys:string, values:string)_                                                                         | (Optional) Simulation Data.                                                                                                                                                                             |
+| `resourceData` _object (keys:string, values:string)_                                                                           | (Optional) Resource Data.                                                                                                                                                                               |
+| `gatlingConf` _object (keys:string, values:string)_                                                                            | (Optional) Gatling Configurations.                                                                                                                                                                      |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#envvar-v1-core) array_                    | (Optional) Environment variables used for running load testing scenario.                                                                                                                                |
+| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#volumemount-v1-core) array_ | (Optional) Pod volumes to mount into the container's filesystem.                                                                                                                                        |
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,7 +24,8 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `provider` _string_ | (Required) Provider specifies the cloud provider that will be used. Supported providers: `aws`, `gcp`, and `azure` |
+| `provider` _string_ | (Required) Provider specifies the cloud provider that will be used.
+Supported providers: `aws`, `gcp`, and `azure` |
 | `bucket` _string_ | (Required) Storage Bucket Name. |
 | `region` _string_ | (Optional) Region Name. |
 | `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#envvar-v1-core) array_ | (Optional) Environment variables used for connecting to the cloud providers. |
@@ -82,7 +83,8 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `provider` _string_ | (Required) Provider specifies notification service provider. Supported providers: `slack` |
+| `provider` _string_ | (Required) Provider specifies notification service provider.
+Supported providers: `slack` |
 | `secretName` _string_ | (Required) The name of secret in which all key/value sets needed for the notification are stored. |
 
 
@@ -145,19 +147,19 @@ TestScenarioSpec defines the load testing scenario
 _Appears in:_
 - [GatlingSpec](#gatlingspec)
 
-| Field                                                                                                                          | Description                                                                                                                                                                                             |
-|--------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `startTime` _string_                                                                                                           | (Optional) Test Start time.                                                                                                                                                                             |
-| `parallelism` _integer_                                                                                                        | (Optional) Number of pods running at the same time. Defaults to `1` (Minimum `1`)                                                                                                                       |
-| `simulationFormat` _string_                                                                                                    | (Optional) Simulation format, should be one of `bundle` / `gradle`. Defaults to `bundle`. In case `gradle` one is chosen, all bundle-specific properties (e.g. `simulationsDirectoryPath`) are ignored. |
-| `simulationsDirectoryPath` _string_                                                                                            | (Optional) Gatling Resources directory path where simulation files are stored. Defaults to `/opt/gatling/user-files/simulations`                                                                        |
-| `resourcesDirectoryPath` _string_                                                                                              | (Optional) Gatling Simulation directory path where resources are stored. Defaults to `/opt/gatling/user-files/resources`                                                                                |
-| `resultsDirectoryPath` _string_                                                                                                | (Optional) Gatling Results directory path where results are stored. Defaults to `/opt/gatling/results`                                                                                                  |
-| `simulationClass` _string_                                                                                                     | (Required) Simulation Class Name.                                                                                                                                                                       |
-| `simulationData` _object (keys:string, values:string)_                                                                         | (Optional) Simulation Data.                                                                                                                                                                             |
-| `resourceData` _object (keys:string, values:string)_                                                                           | (Optional) Resource Data.                                                                                                                                                                               |
-| `gatlingConf` _object (keys:string, values:string)_                                                                            | (Optional) Gatling Configurations.                                                                                                                                                                      |
-| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#envvar-v1-core) array_                    | (Optional) Environment variables used for running load testing scenario.                                                                                                                                |
-| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#volumemount-v1-core) array_ | (Optional) Pod volumes to mount into the container's filesystem.                                                                                                                                        |
+| Field | Description |
+| --- | --- |
+| `startTime` _string_ | (Optional) Test Start time. |
+| `parallelism` _integer_ | (Optional) Number of pods running at the same time. Defaults to `1` (Minimum `1`) |
+| `simulationsFormat` _string_ | (Optional) Gatling simulation format, supports `bundle` and `gradle`. Defaults to `bundle` |
+| `simulationsDirectoryPath` _string_ | (Optional) Gatling Resources directory path where simulation files are stored. Defaults to `/opt/gatling/user-files/simulations` |
+| `resourcesDirectoryPath` _string_ | (Optional) Gatling Simulation directory path where resources are stored. Defaults to `/opt/gatling/user-files/resources` |
+| `resultsDirectoryPath` _string_ | (Optional) Gatling Results directory path where results are stored. Defaults to `/opt/gatling/results` |
+| `simulationClass` _string_ | (Required) Simulation Class Name. |
+| `simulationData` _object (keys:string, values:string)_ | (Optional) Simulation Data. |
+| `resourceData` _object (keys:string, values:string)_ | (Optional) Resource Data. |
+| `gatlingConf` _object (keys:string, values:string)_ | (Optional) Gatling Configurations. |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#envvar-v1-core) array_ | (Optional) Environment variables used for running load testing scenario. |
+| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#volumemount-v1-core) array_ | (Optional) Pod volumes to mount into the container's filesystem. |
 
 

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -32,15 +32,18 @@ done
 }
 
 func GetGatlingRunnerCommand(
-	simulationsDirectoryPath string, tempSimulationsDirectoryPath string, resourcesDirectoryPath string,
-	resultsDirectoryPath string, startTime string, simulationClass string, generateLocalReport bool) string {
+	simulationsFormat string, simulationsDirectoryPath string, tempSimulationsDirectoryPath string,
+	resourcesDirectoryPath string, resultsDirectoryPath string, startTime string, simulationClass string,
+	generateLocalReport bool) string {
 
 	template := `
+SIMULATIONS_FORMAT=%s
 SIMULATIONS_DIR_PATH=%s
 TEMP_SIMULATIONS_DIR_PATH=%s
 RESOURCES_DIR_PATH=%s
 RESULTS_DIR_PATH=%s
 START_TIME="%s"
+SIMULATION_CLASS=%s
 RUN_STATUS_FILE="${RESULTS_DIR_PATH}/COMPLETED"
 if [ -z "${START_TIME}" ]; then
   START_TIME=$(date +"%%Y-%%m-%%d %%H:%%M:%%S" --utc)
@@ -66,7 +69,12 @@ fi
 if [ ! -d ${RESULTS_DIR_PATH} ]; then
   mkdir -p ${RESULTS_DIR_PATH}
 fi
-gatling.sh -sf ${SIMULATIONS_DIR_PATH} -s %s -rsf ${RESOURCES_DIR_PATH} -rf ${RESULTS_DIR_PATH} %s %s
+
+if [ ${SIMULATIONS_FORMAT} = "bundle" ]; then
+  gatling.sh -sf ${SIMULATIONS_DIR_PATH} -s ${SIMULATION_CLASS} -rsf ${RESOURCES_DIR_PATH} -rf ${RESULTS_DIR_PATH} %s %s
+elif [ ${SIMULATIONS_FORMAT} = "gradle" ]; then
+  ./gradlew -Dgatling.core.directory.results=${RESULTS_DIR_PATH} gatlingRun-${SIMULATION_CLASS} 
+fi
 
 GATLING_EXIT_STATUS=$?
 if [ $GATLING_EXIT_STATUS -ne 0 ]; then
@@ -84,6 +92,7 @@ exit $GATLING_EXIT_STATUS
 	runModeOptionLocal := "-rm local"
 
 	return fmt.Sprintf(template,
+		simulationsFormat,
 		simulationsDirectoryPath,
 		tempSimulationsDirectoryPath,
 		resourcesDirectoryPath,

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -73,7 +73,7 @@ fi
 if [ ${SIMULATIONS_FORMAT} = "bundle" ]; then
   gatling.sh -sf ${SIMULATIONS_DIR_PATH} -s ${SIMULATION_CLASS} -rsf ${RESOURCES_DIR_PATH} -rf ${RESULTS_DIR_PATH} %s %s
 elif [ ${SIMULATIONS_FORMAT} = "gradle" ]; then
-  ./gradlew -Dgatling.core.directory.results=${RESULTS_DIR_PATH} gatlingRun-${SIMULATION_CLASS} 
+  gradle -Dgatling.core.directory.results=${RESULTS_DIR_PATH} gatlingRun-${SIMULATION_CLASS} 
 fi
 
 GATLING_EXIT_STATUS=$?

--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -91,7 +91,7 @@ fi
 if [ ${SIMULATIONS_FORMAT} = "bundle" ]; then
   gatling.sh -sf ${SIMULATIONS_DIR_PATH} -s ${SIMULATION_CLASS} -rsf ${RESOURCES_DIR_PATH} -rf ${RESULTS_DIR_PATH}  -rm local
 elif [ ${SIMULATIONS_FORMAT} = "gradle" ]; then
-  ./gradlew -Dgatling.core.directory.results=${RESULTS_DIR_PATH} gatlingRun-${SIMULATION_CLASS} 
+  gradle -Dgatling.core.directory.results=${RESULTS_DIR_PATH} gatlingRun-${SIMULATION_CLASS} 
 fi
 
 GATLING_EXIT_STATUS=$?
@@ -144,7 +144,7 @@ fi
 if [ ${SIMULATIONS_FORMAT} = "bundle" ]; then
   gatling.sh -sf ${SIMULATIONS_DIR_PATH} -s ${SIMULATION_CLASS} -rsf ${RESOURCES_DIR_PATH} -rf ${RESULTS_DIR_PATH} -nr -rm local
 elif [ ${SIMULATIONS_FORMAT} = "gradle" ]; then
-  ./gradlew -Dgatling.core.directory.results=${RESULTS_DIR_PATH} gatlingRun-${SIMULATION_CLASS} 
+  gradle -Dgatling.core.directory.results=${RESULTS_DIR_PATH} gatlingRun-${SIMULATION_CLASS} 
 fi
 
 GATLING_EXIT_STATUS=$?

--- a/pkg/commands/suite_test.go
+++ b/pkg/commands/suite_test.go
@@ -1,0 +1,13 @@
+package commands
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBucket(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Commands Suite")
+}


### PR DESCRIPTION
### Description

Gatling scenarios can be defined in two ways at the moment:
- via hardcoded `simulationData`
- or via custom docker image. However, the only accepted format is Gatling Bundle, which has its own limitations. For example, we cannot define simulation in languages other than Scala, while Gatling supports Kotlin and Java ootb.

Furthermore, I'd like to make use of build tool, sth like that:
- https://gatling.io/blog/migrate-to-the-gradle-build-tool
- https://github.com/gatling/gatling-gradle-plugin-demo-kotlin

My proposal is to add a new property - `simulationsFormat` - which modifies the command being run by `gatling-runner` - it only decides whether we should use `gatling.sh` or gradle wrapper for the test execution. I've already checked the changed on my private EKS cluster, and they seem to work correctly, including features like S3 results upload.

Tomorrow I'll add some examples and update docs. Let me know please @kane8n @gold-kou what are your thoughts. Cheers!

### Checklist

_Please check if applicable_

- [x] Tests have been added (if applicable, ie. when operator codes are added or modified)
- [x] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified)