### PR TITLE
Gatling 3.11 upgrade

### DIFF
--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -73,7 +73,7 @@ fi
 if [ ${SIMULATIONS_FORMAT} = "bundle" ]; then
   gatling.sh -sf ${SIMULATIONS_DIR_PATH} -s ${SIMULATION_CLASS} -rsf ${RESOURCES_DIR_PATH} -rf ${RESULTS_DIR_PATH} %s %s
 elif [ ${SIMULATIONS_FORMAT} = "gradle" ]; then
-  gradle -Dgatling.core.directory.results=${RESULTS_DIR_PATH} gatlingRun-${SIMULATION_CLASS} 
+  gradle -Dgatling.core.directory.results=${RESULTS_DIR_PATH} --simulation=${SIMULATION_CLASS}
 fi
 
 GATLING_EXIT_STATUS=$?

--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -91,7 +91,7 @@ fi
 if [ ${SIMULATIONS_FORMAT} = "bundle" ]; then
   gatling.sh -sf ${SIMULATIONS_DIR_PATH} -s ${SIMULATION_CLASS} -rsf ${RESOURCES_DIR_PATH} -rf ${RESULTS_DIR_PATH}  -rm local
 elif [ ${SIMULATIONS_FORMAT} = "gradle" ]; then
-  gradle -Dgatling.core.directory.results=${RESULTS_DIR_PATH} gatlingRun-${SIMULATION_CLASS} 
+  gradle -Dgatling.core.directory.results=${RESULTS_DIR_PATH} --simulation=${SIMULATION_CLASS}
 fi
 
 GATLING_EXIT_STATUS=$?
@@ -144,7 +144,7 @@ fi
 if [ ${SIMULATIONS_FORMAT} = "bundle" ]; then
   gatling.sh -sf ${SIMULATIONS_DIR_PATH} -s ${SIMULATION_CLASS} -rsf ${RESOURCES_DIR_PATH} -rf ${RESULTS_DIR_PATH} -nr -rm local
 elif [ ${SIMULATIONS_FORMAT} = "gradle" ]; then
-  gradle -Dgatling.core.directory.results=${RESULTS_DIR_PATH} gatlingRun-${SIMULATION_CLASS} 
+  gradle -Dgatling.core.directory.results=${RESULTS_DIR_PATH} --simulation=${SIMULATION_CLASS}
 fi
 
 GATLING_EXIT_STATUS=$?


### PR DESCRIPTION
### Description

https://docs.gatling.io/release-notes/oss/upgrading/3.10-to-3.11/#upgrading-the-gatling-gradle-plugin-to-3110

> It now uses a --simulation=<FullyQualifiedClassName> option to force the desired simulation instead of the non-standard gatlingRun-<FullyQualifiedClassName> pattern.

### Checklist

_Please check if applicable_

- [ ] Tests have been added (if applicable, ie. when operator codes are added or modified)
- [ ] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified)

<!--
  Make sure to link the related issue for this change
-->
Relevant issue #
