### PR TITLE
feat: (unsuccessful) upgrade to 3.11 gatling-gradle and project future 💔

### DIFF
--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -55,6 +55,40 @@ var _ = Describe("GetGatlingRunnerCommand", func() {
 	It("GetCommandsWithLocalReport", func() {
 		generateLocalReport = true
 		expectedValue = `
+can_use_gatling_3_11_syntax() {
+  version=$1
+
+  # if the version can't be find/parsed, it's better to allow use of newer syntax
+  if [ -z "${version}" ]; then
+	echo 0
+	return
+  fi
+
+  ver_major=$(echo "$version" | cut -d. -f1)
+  ver_minor=$(echo "$version" | cut -d. -f2)
+
+  # Compare major versions
+  if [ "$ver_major" -gt "3" ]; then
+	echo 0
+	return
+  elif [ "$ver_major" -lt "3" ]; then
+	echo 1
+	return
+  fi
+
+  # Compare minor versions
+  if [ "$ver_minor" -gt "10" ]; then
+	echo 0
+	return
+  elif [ "$ver_minor" -lt "10" ]; then
+	echo 1
+	return
+  fi
+
+  # you can't use 3.11 syntax, you're running 3.10.x
+  echo 1
+}
+
 SIMULATIONS_FORMAT=bundle
 SIMULATIONS_DIR_PATH=testSimulationDirectoryPath
 TEMP_SIMULATIONS_DIR_PATH=testTempSimulationsDirectoryPath
@@ -91,7 +125,12 @@ fi
 if [ ${SIMULATIONS_FORMAT} = "bundle" ]; then
   gatling.sh -sf ${SIMULATIONS_DIR_PATH} -s ${SIMULATION_CLASS} -rsf ${RESOURCES_DIR_PATH} -rf ${RESULTS_DIR_PATH}  -rm local
 elif [ ${SIMULATIONS_FORMAT} = "gradle" ]; then
-  gradle -Dgatling.core.directory.results=${RESULTS_DIR_PATH} gatlingRun-${SIMULATION_CLASS} 
+  gatling_ver=$(find . -name "build.gradle*" -execdir gradle buildEnvironment \; | grep 'gatling-gradle-plugin:' | sed -n 's/.*:gatling-gradle-plugin:\(.*\)$/\1/p')
+  if [ $(can_use_gatling_3_11_syntax "${gatling_ver}") -eq 0 ]; then
+    gradle -Dgatling.core.directory.results=${RESULTS_DIR_PATH} gatlingRun --simulation=${SIMULATION_CLASS}
+  else
+    gradle -Dgatling.core.directory.results=${RESULTS_DIR_PATH} gatlingRun-${SIMULATION_CLASS}
+  fi
 fi
 
 GATLING_EXIT_STATUS=$?
@@ -108,6 +147,40 @@ exit $GATLING_EXIT_STATUS
 	It("GetCommandWithoutLocalReport", func() {
 		generateLocalReport = false
 		expectedValue = `
+can_use_gatling_3_11_syntax() {
+  version=$1
+
+  # if the version can't be find/parsed, it's better to allow use of newer syntax
+  if [ -z "${version}" ]; then
+	echo 0
+	return
+  fi
+
+  ver_major=$(echo "$version" | cut -d. -f1)
+  ver_minor=$(echo "$version" | cut -d. -f2)
+
+  # Compare major versions
+  if [ "$ver_major" -gt "3" ]; then
+	echo 0
+	return
+  elif [ "$ver_major" -lt "3" ]; then
+	echo 1
+	return
+  fi
+
+  # Compare minor versions
+  if [ "$ver_minor" -gt "10" ]; then
+	echo 0
+	return
+  elif [ "$ver_minor" -lt "10" ]; then
+	echo 1
+	return
+  fi
+
+  # you can't use 3.11 syntax, you're running 3.10.x
+  echo 1
+}
+
 SIMULATIONS_FORMAT=bundle
 SIMULATIONS_DIR_PATH=testSimulationDirectoryPath
 TEMP_SIMULATIONS_DIR_PATH=testTempSimulationsDirectoryPath
@@ -144,7 +217,12 @@ fi
 if [ ${SIMULATIONS_FORMAT} = "bundle" ]; then
   gatling.sh -sf ${SIMULATIONS_DIR_PATH} -s ${SIMULATION_CLASS} -rsf ${RESOURCES_DIR_PATH} -rf ${RESULTS_DIR_PATH} -nr -rm local
 elif [ ${SIMULATIONS_FORMAT} = "gradle" ]; then
-  gradle -Dgatling.core.directory.results=${RESULTS_DIR_PATH} gatlingRun-${SIMULATION_CLASS} 
+  gatling_ver=$(find . -name "build.gradle*" -execdir gradle buildEnvironment \; | grep 'gatling-gradle-plugin:' | sed -n 's/.*:gatling-gradle-plugin:\(.*\)$/\1/p')
+  if [ $(can_use_gatling_3_11_syntax "${gatling_ver}") -eq 0 ]; then
+    gradle -Dgatling.core.directory.results=${RESULTS_DIR_PATH} gatlingRun --simulation=${SIMULATION_CLASS}
+  else
+    gradle -Dgatling.core.directory.results=${RESULTS_DIR_PATH} gatlingRun-${SIMULATION_CLASS}
+  fi
 fi
 
 GATLING_EXIT_STATUS=$?


### PR DESCRIPTION
### Description

Follow-up to the PR https://github.com/st-tech/gatling-operator/pull/120: the change introduces backward compatible upgrade to the gatling-gradle plugin 3.11+. IMHO we should simply support 3.11 syntax and make it clear, that starting from gatling-operator release x.y.z, only gradle plugin 3.11+ is supported, but I've encountered a much bigger problem while doing the upgrade 😭 

`gatling-operator` expect that Gatling can accept `gatling.core.directory.results` param, but starting from version 3.11, it's not supported at all, without any alternatives:
- [3.10 supported params](https://github.com/gatling/gatling/blob/v3.10.5/gatling-core/src/main/resources/gatling-defaults.conf)
- [3.11+ supported params](https://github.com/gatling/gatling/blob/v3.11.0/gatling-core/src/main/resources/gatling-defaults.conf)

Probably we can deal with this problem somehow, but then I checked out what "features" are introduced by 3.12.x Gatling upgrade 😡 It has turned out that they intentionally dropped support for combing the results from multiple runs into one aggregated report, on which `gatling-operator` depends on. Please check out:
- https://stackoverflow.com/questions/78981709/how-to-combine-gatling-reports-from-multiple-machines
- https://github.com/gatling/gatling/issues/4591
- https://community.gatling.io/t/missing-command-line-options-in-gatling-3-11-bundles/9311

It seems that Gatling authors want to encourage the community to pay for this feature and use Gatling Enterprise instead 😞

For us, it means that report aggregation & upload doesn't work anymore, and it can't be fixed. Report aggregation and remote upload are the main reasons people use `gatling-operator`, so I started wondering what the future holds for this project 💔 

I hope I made a mistake somewhere @kane8n - please check it out carefully and come back to me, please. 

### Checklist

- [x] Tests have been added (if applicable, ie. when operator codes are added or modified)
- [x] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified)

Related issues:
- https://github.com/st-tech/gatling-operator/pull/120