### PR TITLE
Modify kubectl image registry(bitnami/kubectl to bitnamilegacy/kubectl)

### DIFF
--- a/controllers/gatling_controller.go
+++ b/controllers/gatling_controller.go
@@ -571,7 +571,7 @@ func (r *GatlingReconciler) newGatlingRunnerJobForCR(gatling *gatlingv1alpha1.Ga
 						InitContainers: []corev1.Container{
 							{
 								Name:      "gatling-waiter",
-								Image:     "bitnami/kubectl:1.29.3",
+								Image:     "bitnamilegacy/kubectl:1.29.3",
 								Command:   []string{"/bin/sh", "-c"},
 								Args:      []string{gatlingWaiterCommand},
 								Resources: r.getPodResources(gatling),
@@ -640,7 +640,7 @@ func (r *GatlingReconciler) newGatlingRunnerJobForCR(gatling *gatlingv1alpha1.Ga
 					InitContainers: []corev1.Container{
 						{
 							Name:      "gatling-waiter",
-							Image:     "bitnami/kubectl:1.29.3",
+							Image:     "bitnamilegacy/kubectl:1.29.3",
 							Command:   []string{"/bin/sh", "-c"},
 							Args:      []string{gatlingWaiterCommand},
 							Resources: r.getPodResources(gatling),


### PR DESCRIPTION
### Description

The kubectl container image currently in use has been removed from the registry, causing an ImagePullBackOff error. Therefore, we are switching from bitnami/kubectl to bitnamilegacy/kubectl.
ref: https://github.com/bitnami/containers/issues/83267

### Checklist

_Please check if applicable_

- [ ] Tests have been added (if applicable, ie. when operator codes are added or modified)
- [ ] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified)

<!--
  Make sure to link the related issue for this change
-->
Relevant issue #
