### PR TITLE
[Bug]: kube-rbac-proxy sidecar missing / not configured in controller-manager deployment

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -11,10 +11,10 @@ spec:
       containers:
       - name: manager
         args:
-          - "--health-probe-bind-address=:8081"
-          - "--metrics-bind-address=:8443"
-          - "--leader-elect"
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=:8443"
+        - "--leader-elect"
         ports:
-          - containerPort: 8443
-            protocol: TCP
-            name: https
+        - containerPort: 8443
+          protocol: TCP
+          name: https

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -9,12 +9,12 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
-          args:
-            - "--health-probe-bind-address=:8081"
-            - "--metrics-bind-address=:8443"
-            - "--leader-elect"
-          ports:
-            - containerPort: 8443
-              protocol: TCP
-              name: https
+      - name: manager
+        args:
+          - "--health-probe-bind-address=:8081"
+          - "--metrics-bind-address=:8443"
+          - "--leader-elect"
+        ports:
+          - containerPort: 8443
+            protocol: TCP
+            name: https

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -9,12 +9,19 @@ spec:
   template:
     spec:
       containers:
+      - name: kube-rbac-proxy
+        image: quay.io/brancz/kube-rbac-proxy:v0.21.2
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"
-        - "--metrics-bind-address=:8443"
+        - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
-        ports:
-        - containerPort: 8443
-          protocol: TCP
-          name: https
+        - "--max-concurrent-reconciles=1"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -9,19 +9,12 @@ spec:
   template:
     spec:
       containers:
-      - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-        args:
-        - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
-        - "--v=10"
-        ports:
-        - containerPort: 8443
-          name: https
-      - name: manager
-        args:
-        - "--health-probe-bind-address=:8081"
-        - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"
-        - "--max-concurrent-reconciles=1"
+        - name: manager
+          args:
+            - "--health-probe-bind-address=:8081"
+            - "--metrics-bind-address=:8443"
+            - "--leader-elect"
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+              name: https


### PR DESCRIPTION
### Description
I had applied the controller manager resource in my GKE cluster, I faced a `ImagePullBackoff` error in the resource this month.

I investigated similar issues in other repos, a solution is to remove `kube-rbac-proxy` images from controller manager resource.
Once I reflected it to this repo, it works as expected.

#### Related issues in other repositories:
- https://github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/pull/747
- https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/pull/372

### Checklist

- [x] Tests have been added (if applicable, ie. when operator codes are added or modified)
- [x] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified)

<!--
  Make sure to link the related issue for this change
-->
Relevant issue #134 