### PR TITLE
fix trivy-action version

### DIFF
--- a/.github/workflows/daily-vul-scan.yml
+++ b/.github/workflows/daily-vul-scan.yml
@@ -37,7 +37,7 @@ jobs:
           make docker-build IMG="${{ env.IMAGE_NAME }}:${{ github.sha }}"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.18.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: image
           image-ref: "${{ env.IMAGE_NAME }}:${{ github.sha }}"


### PR DESCRIPTION
### Description

Update the aquasecurity/trivy-action from 0.18.0 to 0.35.0 in the daily vulnerability scan workflow.

The action is now pinned to a full commit SHA (57a97c7e7821a5776cebc9bb87c984fa69cba8f1) instead of a mutable tag, following GitHub Actions security best practices to prevent supply chain attacks via tag tampering. The version is noted in a trailing comment for readability.

### Checklist

_Please check if applicable_

- [ ] Tests have been added (if applicable, ie. when operator codes are added or modified)
- [ ] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified)

<!--
  Make sure to link the related issue for this change
-->
Relevant issue #
